### PR TITLE
Force skip version if draft

### DIFF
--- a/repo/github_release.go
+++ b/repo/github_release.go
@@ -148,7 +148,13 @@ func (g *GithubRelease) latest() (*github.RepositoryRelease, error) {
 		if err != nil {
 			return nil, err
 		}
-		r = rr[0]
+		for _, v := range rr {
+			if *v.Draft {
+				continue
+			}
+			r = v
+			break
+		}
 	} else {
 		r, _, err = c.Repositories.GetLatestRelease(ctx, g.owner, g.name)
 	}


### PR DESCRIPTION
The draft is forced through because the draft is visible depending on the authority.

> Only users with push access will receive listings for draft releases.
> https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository