### PR TITLE
Dewy does not support config file. Instead, it uses environment variables.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -25,7 +25,6 @@ type cli struct {
 	env        Env
 	command    string
 	args       []string
-	Config     string `long:"config" short:"c" description:"Path to configuration file"`
 	LogLevel   string `long:"log-level" short:"l" arg:"(debug|info|warn|error)" description:"Level displayed as log"`
 	Interval   int    `long:"interval" arg:"seconds" short:"i" description:"The polling interval to the repository (default: 10)"`
 	Port       string `long:"port" short:"p" description:"TCP port to listen"`


### PR DESCRIPTION
This PR is also a proposal.

Dewy originally did not implement loading configuration files.
Therefore, I would like to continue using environment variables as the primary means of reading configurations.