### PR TITLE
Detect artifact using GOOS and GOARCH

### DIFF
--- a/dewy.go
+++ b/dewy.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"sync"
 	"syscall"
@@ -124,6 +125,8 @@ func (d *Dewy) Run() error {
 
 	// Get current
 	res, err := d.registory.Current(&registory.CurrentRequest{
+		Arch:         runtime.GOARCH,
+		OS:           runtime.GOOS,
 		ArtifactName: d.config.Repository.Artifact,
 	})
 	if err != nil {

--- a/dewy_test.go
+++ b/dewy_test.go
@@ -62,7 +62,6 @@ func TestRun(t *testing.T) {
 	c.Repository = repo.Config{
 		Owner:                 "linyows",
 		Repo:                  "dewy",
-		Artifact:              "dewy_darwin_x86_64.tar.gz",
 		DisableRecordShipping: true,
 	}
 	c.Cache = CacheConfig{

--- a/registory/registory.go
+++ b/registory/registory.go
@@ -9,6 +9,10 @@ type Registory interface {
 
 // CurrentRequest is the request to get the current artifact.
 type CurrentRequest struct {
+	// Arch is the CPU architecture of deployment environment.
+	Arch string
+	// OS is the operating system of deployment environment.
+	OS string
 	// ArtifactName is the name of the artifact to fetch.
 	// FIXME: If possible, ArtifactName should be optional.
 	ArtifactName string


### PR DESCRIPTION
Some tools may include version number in asset names.

ref: https://github.com/cli/cli/releases/tag/v2.36.0

For this reason, if we need to specify the asset name (artifact name), we will not be able to download the latest assets.

In this change, I tried to detect the asset name as much as possible using GOOS and GOARCH.
