### PR TITLE
Accept options from query string of registry URL

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -28,10 +28,10 @@ type cli struct {
 	LogLevel   string `long:"log-level" short:"l" arg:"(debug|info|warn|error)" description:"Level displayed as log"`
 	Interval   int    `long:"interval" arg:"seconds" short:"i" description:"The polling interval to the repository (default: 10)"`
 	Port       string `long:"port" short:"p" description:"TCP port to listen"`
-	Repository string `long:"repository" short:"r" description:"Repository for application"`
+	Repository string `long:"repository" short:"r" description:"[DEPRECATED] Repository for application"`
 	Registry   string `long:"registry" description:"Registry for application"`
-	Artifact   string `long:"artifact" short:"a" description:"Artifact name for application"`
-	PreRelease bool   `long:"pre" short:"P" description:"Pre-release handling (default: false)"`
+	Artifact   string `long:"artifact" short:"a" description:"[DEPRECATED] Artifact name for application"`
+	PreRelease bool   `long:"pre" short:"P" description:"[DEPRECATED] Pre-release handling (default: false)"`
 	Help       bool   `long:"help" short:"h" description:"show this help message and exit"`
 	Version    bool   `long:"version" short:"v" description:"prints the version number"`
 }

--- a/dewy.go
+++ b/dewy.go
@@ -67,10 +67,14 @@ func New(c Config) (*Dewy, error) {
 		return nil, err
 	}
 	if c.PreRelease {
-		u.Query().Add("pre-release", "true")
+		v := u.Query()
+		v.Add("pre-release", "true")
+		u.RawQuery = v.Encode()
 	}
 	if c.ArtifactName != "" {
-		u.Query().Add("artifact", c.ArtifactName)
+		v := u.Query()
+		v.Add("artifact", c.ArtifactName)
+		u.RawQuery = v.Encode()
 	}
 	c.Registry = fmt.Sprintf("%s://%s", su[0], u.String())
 

--- a/dewy_test.go
+++ b/dewy_test.go
@@ -116,18 +116,20 @@ func TestNew(t *testing.T) {
 	regiurl := "github_release://linyows/dewy"
 	c := DefaultConfig()
 	c.Registry = regiurl
+	c.PreRelease = true
 	dewy, err := New(c)
 	if err != nil {
 		t.Fatal(err)
 	}
 	wd, _ := os.Getwd()
-	r, err := newRegistry(regiurl)
+	r, err := newRegistry(regiurl + "?pre-release=true")
 	if err != nil {
 		t.Fatal(err)
 	}
 	expect := &Dewy{
 		config: Config{
-			Registry: regiurl,
+			Registry:   regiurl + "?pre-release=true",
+			PreRelease: true,
 			Cache: CacheConfig{
 				Type:       FILE,
 				Expiration: 10,

--- a/dewy_test.go
+++ b/dewy_test.go
@@ -1,15 +1,116 @@
 package dewy
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/k1LoW/grpcstub"
 	"github.com/linyows/dewy/kvs"
+	"github.com/linyows/dewy/registry"
 	ghrelease "github.com/linyows/dewy/registry/github_release"
+	"github.com/linyows/dewy/registry/grpc"
 )
+
+func TestNewRegistry(t *testing.T) {
+	ts := grpcstub.NewServer(t, "registry/grpc/proto/dewy.proto")
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	tests := []struct {
+		urlstr  string
+		want    registry.Registry
+		wantErr bool
+	}{
+		{
+			"github_release://linyows/dewy",
+			func(t *testing.T) registry.Registry {
+				r, err := ghrelease.New(ghrelease.Config{
+					Owner:      "linyows",
+					Repo:       "dewy",
+					Artifact:   "",
+					PreRelease: false,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			}(t),
+			false,
+		},
+		{
+			"github_release://linyows/dewy?artifact=dewy_linux_amd64",
+			func(t *testing.T) registry.Registry {
+				r, err := ghrelease.New(ghrelease.Config{
+					Owner:      "linyows",
+					Repo:       "dewy",
+					Artifact:   "dewy_linux_amd64",
+					PreRelease: false,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			}(t),
+			false,
+		},
+		{
+			"github_release://linyows/dewy?artifact=dewy_linux_amd64&pre-release=true",
+			func(t *testing.T) registry.Registry {
+				r, err := ghrelease.New(ghrelease.Config{
+					Owner:      "linyows",
+					Repo:       "dewy",
+					Artifact:   "dewy_linux_amd64",
+					PreRelease: true,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			}(t),
+			false,
+		},
+		{
+			fmt.Sprintf("grpc://%s?no-tls=true", ts.Addr()),
+			func(t *testing.T) registry.Registry {
+				r, err := grpc.New(grpc.Config{
+					Target: ts.Addr(),
+					NoTLS:  true,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return r
+			}(t),
+			false,
+		},
+		{
+			"invalid://linyows/dewy",
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.urlstr, func(t *testing.T) {
+			got, err := newRegistry(tt.urlstr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newRegistry() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			opts := []cmp.Option{
+				cmp.AllowUnexported(ghrelease.GithubRelease{}, grpc.Client{}),
+				cmpopts.IgnoreFields(ghrelease.GithubRelease{}, "cl"),
+				cmpopts.IgnoreFields(grpc.Client{}, "cl"),
+			}
+			if diff := cmp.Diff(got, tt.want, opts...); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
 
 func TestNew(t *testing.T) {
 	regiurl := "github_release://linyows/dewy"
@@ -20,7 +121,7 @@ func TestNew(t *testing.T) {
 		t.Fatal(err)
 	}
 	wd, _ := os.Getwd()
-	r, err := newRegistry(regiurl, false, "")
+	r, err := newRegistry(regiurl)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v55 v55.0.0
 	github.com/google/go-querystring v1.1.0
+	github.com/gorilla/schema v1.2.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/k1LoW/go-github-client/v55 v55.0.11

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/googleapis/gax-go/v2 v2.11.0 h1:9V9PWXEsWnPpQhu/PeQIkS4eGzMlTLGgt80cU
 github.com/googleapis/gax-go/v2 v2.11.0/go.mod h1:DxmR61SGKkGLa2xigwuZIQpkCI2S5iydzRfb3peWZJI=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=

--- a/registry/github_release/config.go
+++ b/registry/github_release/config.go
@@ -2,9 +2,9 @@ package ghrelease
 
 // Config struct.
 type Config struct {
-	Owner                 string
-	Repo                  string
-	Artifact              string
-	PreRelease            bool
-	DisableRecordShipping bool // FIXME: For testing. Remove this.
+	Owner                 string `schema:"-"`
+	Repo                  string `schema:"-"`
+	Artifact              string `schema:"artifact"`
+	PreRelease            bool   `schema:"pre-release"`
+	DisableRecordShipping bool   // FIXME: For testing. Remove this.
 }

--- a/registry/grpc/config.go
+++ b/registry/grpc/config.go
@@ -1,0 +1,6 @@
+package grpc
+
+type Config struct {
+	Target string `schema:"-"`
+	NoTLS  bool   `schema:"no-tls"`
+}

--- a/registry/grpc/grpc.go
+++ b/registry/grpc/grpc.go
@@ -6,6 +6,7 @@ import (
 	"github.com/linyows/dewy/registry"
 	dewypb "github.com/linyows/dewy/registry/grpc/proto/gen/dewy"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -19,7 +20,16 @@ type Client struct {
 var _ registry.Registry = (*Client)(nil)
 
 // New returns Client.
-func New(cc grpc.ClientConnInterface) (*Client, error) {
+func New(c Config) (*Client, error) {
+	opts := []grpc.DialOption{}
+	if c.NoTLS {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	cc, err := grpc.Dial(c.Target, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	cl := dewypb.NewRegistryServiceClient(cc)
 	return &Client{
 		cl: cl,

--- a/registry/grpc/grpc_test.go
+++ b/registry/grpc/grpc_test.go
@@ -23,7 +23,11 @@ func TestCurrent(t *testing.T) {
 		Tag:         "v1.0.0",
 		ArtifactUrl: "github_release://linyows/dewy",
 	})
-	client, err := New(ts.ClientConn())
+	c := Config{
+		Target: ts.Addr(),
+		NoTLS:  true,
+	}
+	client, err := New(c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +70,11 @@ func TestReport(t *testing.T) {
 		ts.Close()
 	})
 	ts.Method("Report").Response(&emptypb.Empty{})
-	client, err := New(ts.ClientConn())
+	c := Config{
+		Target: ts.Addr(),
+		NoTLS:  true,
+	}
+	client, err := New(c)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Proposal

Registry options are different for each registry.
Unify the interface by accepting options from the registry URL query string.

- `github_release://linyows/dewy?artifact=dewy_linux_amd64`
- `grpc://192.168.3.3?no-tls=true`