### PR TITLE
Fix misleading notification message

### DIFF
--- a/dewy.go
+++ b/dewy.go
@@ -237,8 +237,8 @@ func (d *Dewy) Run() error {
 		d.logger.Info("Cached artifact", slog.String("cache_key", cachekeyName))
 	}
 
-	msg := fmt.Sprintf("Ready for `%s`", res.Tag)
-	d.logger.Info("New version notification", slog.String("message", msg))
+	msg := fmt.Sprintf("Downloaded artifact for `%s`", res.Tag)
+	d.logger.Info("Download notification", slog.String("message", msg))
 	d.notifier.Send(ctx, msg)
 
 	if err := d.deploy(cachekeyName); err != nil {


### PR DESCRIPTION
## Summary
- Fixed misleading "Ready for version" notification message that was sent immediately after artifact download
- Changed to "Downloaded artifact for version" to accurately reflect the current state
- Updated corresponding log message from "New version notification" to "Download notification"

## Problem
The original message "Ready for v1.2.3" was misleading because it was sent right after downloading the artifact, before the actual deployment process completed. This could confuse users into thinking the new version was ready to use when it was only downloaded.

## Solution
Changed the notification message to clearly indicate that the artifact has been downloaded, which is the actual event being notified at that point in the code.

## Test plan
- [x] All existing tests pass
- [x] Code builds successfully 
- [x] Notification message accurately reflects the download completion event

Fixes #124

🤖 Generated with [Claude Code](https://claude.ai/code)