### PR TITLE
Improve Slack notification with footer design

### DIFF
--- a/dewy.go
+++ b/dewy.go
@@ -102,7 +102,7 @@ func (d *Dewy) Start(i int) {
 		d.logger.Error("Notifier failure", slog.String("error", err.Error()))
 	}
 
-	msg := fmt.Sprintf("Automatic shipping started by *Dewy* (%s)", d.config.Version)
+	msg := fmt.Sprintf("Automatic shipping started by *Dewy* (v%s)", d.config.Version)
 	d.logger.Info("Dewy start notification", slog.String("message", msg))
 	d.notifier.Send(ctx, msg)
 
@@ -136,7 +136,7 @@ func (d *Dewy) waitSigs(ctx context.Context) {
 			if err := d.restartServer(); err != nil {
 				d.logger.Error("Restart failure", slog.String("error", err.Error()))
 			} else {
-				msg := fmt.Sprintf("Restarted receiving by \"%s\" signal", "SIGUSR1")
+				msg := fmt.Sprintf("Restarted receiving by `%s` signal", "SIGUSR1")
 				d.logger.Info("Restart notification", slog.String("message", msg))
 				d.notifier.Send(ctx, msg)
 			}
@@ -144,7 +144,7 @@ func (d *Dewy) waitSigs(ctx context.Context) {
 
 		case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
 			d.job.Quit <- true
-			msg := fmt.Sprintf("Stop receiving by \"%s\" signal", sig)
+			msg := fmt.Sprintf("Stop receiving by `%s` signal", sig)
 			d.logger.Info("Shutdown notification", slog.String("message", msg))
 			d.notifier.Send(ctx, msg)
 			return

--- a/notifier/slack.go
+++ b/notifier/slack.go
@@ -21,10 +21,8 @@ var (
 	SlackUsername = "Dewy"
 	// SlackIconURL variable.
 	SlackIconURL = "https://raw.githubusercontent.com/linyows/dewy/main/misc/dewy-icon.512.png"
-	// SlackFooter variable.
-	SlackFooter = "Dewy notify/slack"
 	// SlackFooterIcon variable.
-	SlackFooterIcon = SlackIconURL
+	SlackFooterIcon = "https://raw.githubusercontent.com/linyows/dewy/main/misc/dewy-icon.32.png"
 
 	decoder = schema.NewDecoder()
 )
@@ -40,7 +38,6 @@ type Slack struct {
 	Title    string `schema:"title"`
 	TitleURL string `schema:"url"`
 	token    string
-	github   *Github
 	sender   SlackSender // for testing
 	logger   *slog.Logger
 }
@@ -96,58 +93,25 @@ func (s *Slack) genColor() string {
 	return strings.ToUpper(fmt.Sprintf("#%x", md5.Sum([]byte(hostname())))[0:7]) //nolint:gosec
 }
 
-// Github struct.
-type Github struct {
-	// linyows
-	Owner string
-	// dewy
-	Repo string
-	// appname_linux_amd64.tar.gz
-	Artifact string
-}
 
-// OwnerURL returns owner URL.
-func (g *Github) OwnerURL() string {
-	return fmt.Sprintf("https://github.com/%s", g.Owner)
-}
-
-// OwnerIconURL returns owner icon URL.
-func (g *Github) OwnerIconURL() string {
-	return fmt.Sprintf("%s.png?size=200", g.OwnerURL())
-}
-
-// URL returns repository URL.
-func (g *Github) RepoURL() string {
-	return fmt.Sprintf("%s/%s", g.OwnerURL(), g.Repo)
-}
-
-// BuildAttachmentByGithubArgs returns attachment for slack.
+// BuildAttachment returns attachment for slack.
 func (s *Slack) BuildAttachment(message string) objects.Attachment {
 	var at objects.Attachment
 	at.Color = s.genColor()
 
-	if s.github != nil {
-		at.Text = message
-		at.Title = s.github.Repo
-		at.TitleLink = s.github.RepoURL()
-		at.AuthorName = s.github.Owner
-		at.AuthorLink = s.github.OwnerURL()
-		at.AuthorIcon = s.github.OwnerIconURL()
-		at.Footer = SlackFooter
-		at.FooterIcon = SlackFooterIcon
-		at.Timestamp = objects.Timestamp(time.Now().Unix())
-		at.Fields.
-			Append(&objects.AttachmentField{Title: "Host", Value: hostname(), Short: true}).
-			Append(&objects.AttachmentField{Title: "User", Value: username(), Short: true}).
-			Append(&objects.AttachmentField{Title: "Source", Value: s.github.Artifact, Short: true}).
-			Append(&objects.AttachmentField{Title: "Working directory", Value: cwd(), Short: false})
-	} else if s.Title != "" && s.TitleURL != "" {
-		at.Text = fmt.Sprintf("%s of <%s|%s> on %s", message, s.TitleURL, s.Title, hostname())
+	// Set message text based on title configuration
+	if s.Title != "" && s.TitleURL != "" {
+		at.Text = fmt.Sprintf("%s of <%s|%s>", message, s.TitleURL, s.Title)
 	} else if s.Title != "" {
-		at.Text = fmt.Sprintf("%s of %s on %s", message, s.Title, hostname())
+		at.Text = fmt.Sprintf("%s of %s", message, s.Title)
 	} else {
-		at.Text = fmt.Sprintf("%s on %s", message, hostname())
+		at.Text = message
 	}
+
+	// Add hostname to footer with timestamp
+	at.Footer = hostname()
+	at.FooterIcon = SlackFooterIcon
+	at.Timestamp = objects.Timestamp(time.Now().Unix())
 
 	return at
 }

--- a/notifier/slack_test.go
+++ b/notifier/slack_test.go
@@ -233,24 +233,6 @@ func TestSlack_BuildAttachment(t *testing.T) {
 		want    func(attachment objects.Attachment) bool
 	}{
 		{
-			name: "attachment with github info",
-			slack: &Slack{
-				Channel: "/general",
-				github: &Github{
-					Owner:    "testowner",
-					Repo:     "testrepo",
-					Artifact: "test-artifact",
-				},
-			},
-			message: "Test message",
-			want: func(attachment objects.Attachment) bool {
-				return attachment.Text == "Test message" &&
-					attachment.Title == "testrepo" &&
-					attachment.AuthorName == "testowner" &&
-					strings.Contains(attachment.TitleLink, "github.com/testowner/testrepo")
-			},
-		},
-		{
 			name: "attachment with title and URL",
 			slack: &Slack{
 				Channel:  "/general",
@@ -261,7 +243,9 @@ func TestSlack_BuildAttachment(t *testing.T) {
 			want: func(attachment objects.Attachment) bool {
 				return strings.Contains(attachment.Text, "Test message") &&
 					strings.Contains(attachment.Text, "Test Project") &&
-					strings.Contains(attachment.Text, "https://example.com")
+					strings.Contains(attachment.Text, "https://example.com") &&
+					attachment.Footer != "" &&
+					attachment.Timestamp != 0
 			},
 		},
 		{
@@ -273,7 +257,9 @@ func TestSlack_BuildAttachment(t *testing.T) {
 			message: "Test message",
 			want: func(attachment objects.Attachment) bool {
 				return strings.Contains(attachment.Text, "Test message") &&
-					strings.Contains(attachment.Text, "Test Project")
+					strings.Contains(attachment.Text, "Test Project") &&
+					attachment.Footer != "" &&
+					attachment.Timestamp != 0
 			},
 		},
 		{
@@ -283,7 +269,9 @@ func TestSlack_BuildAttachment(t *testing.T) {
 			},
 			message: "Test message",
 			want: func(attachment objects.Attachment) bool {
-				return strings.Contains(attachment.Text, "Test message")
+				return strings.Contains(attachment.Text, "Test message") &&
+					attachment.Footer != "" &&
+					attachment.Timestamp != 0
 			},
 		},
 	}
@@ -323,35 +311,6 @@ func TestSlack_genColor(t *testing.T) {
 	}
 }
 
-func TestGithub_OwnerURL(t *testing.T) {
-	github := &Github{Owner: "testowner"}
-	expected := "https://github.com/testowner"
-	got := github.OwnerURL()
-
-	if got != expected {
-		t.Errorf("OwnerURL() = %v, want %v", got, expected)
-	}
-}
-
-func TestGithub_OwnerIconURL(t *testing.T) {
-	github := &Github{Owner: "testowner"}
-	expected := "https://github.com/testowner.png?size=200"
-	got := github.OwnerIconURL()
-
-	if got != expected {
-		t.Errorf("OwnerIconURL() = %v, want %v", got, expected)
-	}
-}
-
-func TestGithub_RepoURL(t *testing.T) {
-	github := &Github{Owner: "testowner", Repo: "testrepo"}
-	expected := "https://github.com/testowner/testrepo"
-	got := github.RepoURL()
-
-	if got != expected {
-		t.Errorf("RepoURL() = %v, want %v", got, expected)
-	}
-}
 
 func TestSlack_SetSender(t *testing.T) {
 	slack := &Slack{}


### PR DESCRIPTION
## Summary

- Add version prefix 'v' to startup notification message for consistency
- Move hostname from message text to footer for cleaner, more readable notifications
- Remove unused Github mode functionality to simplify codebase
- Fix SlackFooterIcon URL to reference existing file (dewy-icon.32.png)
- Add timestamp to all Slack attachments for better context
- Update tests to validate footer and timestamp presence

## Test plan

- [x] All existing tests pass
- [x] Updated test cases validate footer and timestamp functionality
- [x] Verified SlackFooterIcon URL points to existing file
- [x] Confirmed message text no longer contains "on hostname"
- [x] Validated version notification includes "v" prefix

🤖 Generated with [Claude Code](https://claude.ai/code)