### PR TITLE
Improve Slack notification formatting for hook results

### DIFF
--- a/dewy_test.go
+++ b/dewy_test.go
@@ -1082,7 +1082,7 @@ func TestHookStdoutStderrTrimming(t *testing.T) {
 			}
 
 			result := hookResults[0]
-			
+
 			// Verify trimming based on command type
 			if tt.name == "stdout_with_trailing_newlines" {
 				if strings.HasSuffix(result.Stdout, "\n") {
@@ -1092,7 +1092,7 @@ func TestHookStdoutStderrTrimming(t *testing.T) {
 					t.Errorf("%s: Expected stdout to be 'output', but got: %q", tt.description, result.Stdout)
 				}
 			}
-			
+
 			if tt.name == "stderr_with_trailing_spaces" {
 				if strings.HasSuffix(result.Stderr, "\n") || strings.HasSuffix(result.Stderr, " ") {
 					t.Errorf("%s: Expected stderr to be trimmed, but got: %q", tt.description, result.Stderr)
@@ -1101,7 +1101,7 @@ func TestHookStdoutStderrTrimming(t *testing.T) {
 					t.Errorf("%s: Expected stderr to be 'error', but got: %q", tt.description, result.Stderr)
 				}
 			}
-			
+
 			if tt.name == "clean_output" {
 				if result.Stdout != "clean" {
 					t.Errorf("%s: Expected stdout to be 'clean', but got: %q", tt.description, result.Stdout)

--- a/notifier/slack.go
+++ b/notifier/slack.go
@@ -126,12 +126,12 @@ func (s *Slack) BuildHookAttachment(hookType string, result *HookResult) objects
 	at.Title = fmt.Sprintf("%s Hook", hookType)
 
 	// Set command in text field
-	at.Text = fmt.Sprintf("`%s`", result.Command)
+	at.Text = fmt.Sprintf("```\n%s\n```", result.Command)
 
 	// Add exit code and duration fields (short)
 	at.Fields = append(at.Fields, &objects.AttachmentField{
 		Title: "Exit Code",
-		Value: fmt.Sprintf("%d", result.ExitCode),
+		Value: fmt.Sprintf("`%d`", result.ExitCode),
 		Short: true,
 	})
 


### PR DESCRIPTION
## Summary
Enhance the visual formatting of Slack notifications for deploy hook results to improve readability and consistency.

## Changes Made
- **Command display**: Changed from inline code to code block format for better visibility of complex commands
- **Exit code display**: Added inline code formatting to make exit codes stand out
- **Consistency**: Aligned formatting style across all notification fields

## Before/After
### Before:
- Command: `deploy.sh --prod`
- Exit Code: 0

### After:  
- Command:
  ```
  deploy.sh --prod
  ```
- Exit Code: `0`

## Benefits
- Better readability for long/complex commands
- Clear visual distinction for exit codes
- Consistent code formatting throughout notifications
- Enhanced user experience in Slack channels

🤖 Generated with [Claude Code](https://claude.ai/code)