### PR TITLE
Optimize e2e test timing with retry logic

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -3,7 +3,7 @@ name: End-to-end Testing
 on:
   workflow_dispatch:
   push:
-    branches: [main, optimize-e2e-test-retry]
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -3,7 +3,7 @@ name: End-to-end Testing
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, optimize-e2e-test-retry]
 
 jobs:
   test:

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -48,7 +48,7 @@ jobs:
     id: release
     uses: shell
     retry:
-      count: 5
+      max_attempts: 5
       interval: 3s
     with:
       env:
@@ -68,7 +68,7 @@ jobs:
   - name: Verify release exists
     uses: shell
     retry:
-      count: 10
+      max_attempts: 10
       interval: 2s
     with:
       env:

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -47,7 +47,9 @@ jobs:
   - name: Create release
     id: release
     uses: shell
-    wait: 15s
+    retry:
+      count: 5
+      interval: 3s
     with:
       env:
         GH_TOKEN: "{{ vars.github_token }}"
@@ -63,6 +65,18 @@ jobs:
       version: vars.version
     echo: |
       {{res.stdout}}
+  - name: Verify release exists
+    uses: shell
+    retry:
+      count: 10
+      interval: 2s
+    with:
+      env:
+        GH_TOKEN: "{{ vars.github_token }}"
+      cmd: |
+        gh release view {{ outputs.release.version }} \
+          --repo linyows/dewy-testapp
+    test: status == 0
 
 - name: Run server by Github-Releases registry
   needs: [build]

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -47,9 +47,6 @@ jobs:
   - name: Create release
     id: release
     uses: shell
-    retry:
-      max_attempts: 5
-      interval: 3s
     with:
       env:
         GH_TOKEN: "{{ vars.github_token }}"

--- a/testdata/jobs/assets.yml
+++ b/testdata/jobs/assets.yml
@@ -26,7 +26,7 @@ steps:
 - name: Wait for new version download
   uses: shell
   retry:
-    count: 60
+    max_attempts: 60
     interval: 5s
   with:
     cmd: |

--- a/testdata/jobs/assets.yml
+++ b/testdata/jobs/assets.yml
@@ -23,8 +23,29 @@ steps:
     PID: {{ res.pid }}
     Log: {{ res.log }}
 
+- name: Wait for new version download
+  uses: shell
+  retry:
+    count: 60
+    interval: 5s
+  with:
+    cmd: |
+      if [ -f "{{ outputs.server.log }}" ]; then
+        grep "Download notification" "{{ outputs.server.log }}" | \
+          awk '{print $6}' | \
+          grep -q "{{ replace(vars.new_version, 'v', '') }}" && exit 0
+      fi
+      exit 1
+  test: status == 0
+
+- name: Wait for stabilization
+  wait: 30s
+  uses: shell
+  with:
+    cmd: "echo 'Waiting for system stabilization after new version detection'"
+  test: status == 0
+
 - name: Stop dewy
-  wait: 5m
   uses: shell
   with: # Use Process Group ID
     cmd: "kill -TERM -{{ outputs.server.pid }}"

--- a/testdata/jobs/server.yml
+++ b/testdata/jobs/server.yml
@@ -27,7 +27,7 @@ steps:
 - name: Wait for new version to start
   uses: shell
   retry:
-    count: 60
+    max_attempts: 60
     interval: 5s
   with:
     cmd: |

--- a/testdata/jobs/server.yml
+++ b/testdata/jobs/server.yml
@@ -24,8 +24,29 @@ steps:
     PID: {{ res.pid }}
     Log: {{ res.log }}
 
+- name: Wait for new version to start
+  uses: shell
+  retry:
+    count: 60
+    interval: 5s
+  with:
+    cmd: |
+      if [ -f "{{ outputs.server.log }}" ]; then
+        grep "starting version" "{{ outputs.server.log }}" | \
+          awk '{print $6}' | \
+          grep -q "{{ replace(vars.new_version, 'v', '') }}" && exit 0
+      fi
+      exit 1
+  test: status == 0
+
+- name: Wait for stabilization
+  wait: 30s
+  uses: shell
+  with:
+    cmd: "echo 'Waiting for system stabilization after new version detection'"
+  test: status == 0
+
 - name: Stop dewy
-  wait: 5m
   uses: shell
   with: # Use Process Group ID
     cmd: "kill -TERM -{{ outputs.server.pid }}"


### PR DESCRIPTION
Replace fixed wait times with dynamic retry mechanisms:
- Remove 15s fixed wait for release creation, add retry logic
- Replace 5m fixed waits with version detection + 30s stabilization
- Improve test reliability and reduce unnecessary waiting

🤖 Generated with [Claude Code](https://claude.ai/code)