### PR TITLE
Add E2E test for container command

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -8,6 +8,12 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'testdata/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .dewy/
 /testdata/server
 /testdata/assets
+/testdata/container

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,15 @@ build:
 	go build ./cmd/dewy
 
 server:
-	go run cmd/dewy/main.go server --registry ghr://linyows/dewy-testapp -p 8000 -l $(LOGLEVEL) -- $(HOME)/.go/src/github.com/linyows/dewy/current/dewy-testapp
+	go run cmd/dewy/main.go server --registry ghr://linyows/dewy-testapp?pre-release=true \
+		-p 8000 -l $(LOGLEVEL) -- $(HOME)/.go/src/github.com/linyows/dewy/current/dewy-testapp
 
 assets:
-	go run cmd/dewy/main.go assets --registry ghr://linyows/dewy-testapp -l $(LOGLEVEL)
+	go run cmd/dewy/main.go assets --registry ghr://linyows/dewy-testapp?pre-release=true -l $(LOGLEVEL)
+
+container:
+	go run cmd/dewy/main.go container --registry 'img://ghcr.io/linyows/dewy-testapp?pre-release=true' \
+		-p 8000 --health-path /health --container-port 3333 -l $(LOGLEVEL) --replicas 3
 
 protobuf:
 	cd registry && go tool buf generate

--- a/dewy.go
+++ b/dewy.go
@@ -703,7 +703,7 @@ func (d *Dewy) RunContainer() error {
 	if totalReplicas <= 0 {
 		totalReplicas = 1
 	}
-	msg = fmt.Sprintf("Container deployed successfully: %d/%d replicas of `%s`", deployedCount, totalReplicas, d.cVer)
+	msg = fmt.Sprintf("Container deployed successfully: `%d/%d` replicas of `%s`", deployedCount, totalReplicas, d.cVer)
 	d.logger.Info("Container deployed successfully",
 		slog.String("version", d.cVer),
 		slog.Int("replicas", deployedCount),

--- a/docs/design/container-command.md
+++ b/docs/design/container-command.md
@@ -20,6 +20,7 @@ This document describes the design for adding container image deployment functio
 2. **Advanced Load Balancing**: Weighted round-robin, sticky sessions, etc. are out of scope for initial version
 3. **Kubernetes-Equivalent Features**: Service discovery, ConfigMap, Secrets, etc. are out of scope
 4. **Auto-Scaling**: Dynamic adjustment of replica count is out of scope
+5. **Audit Support**: Deployment history tracking is not supported for OCI registries (see Limitations section)
 
 # Background
 
@@ -294,6 +295,7 @@ Downtime: **0 seconds** (at least one replica always running)
 1. **Single Host Limitation**: Distributed deployment to multiple servers is not supported
 2. **Load Balancing**: Round-robin only (weighted, sticky sessions, etc. not supported)
 3. **Health Checks**: HTTP GET only (TCP, gRPC, etc. not supported)
+4. **Audit Information**: Deployment history tracking is not supported
 
 ### Future Expansion Possibilities
 

--- a/docs/pages/ja/registry.md
+++ b/docs/pages/ja/registry.md
@@ -177,6 +177,10 @@ myapp/v1.2.3/myapp_linux_amd64.tar.gz
 
 OCI準拠のコンテナレジストリは、`dewy container`コマンドでコンテナイメージのデプロイメントに使用できます。
 
+{% callout type="caution" %}
+OCIレジストリでは監査追跡（Audit tracking）に対応していません。
+{% /callout %}
+
 ### 対応レジストリ
 
 DewyはOCI Distribution Specification準拠のすべてのレジストリをサポートしています：

--- a/docs/pages/registry.md
+++ b/docs/pages/registry.md
@@ -167,6 +167,10 @@ myapp/v1.2.3/myapp_linux_amd64.tar.gz
 
 OCI-compliant container registries can be used for container image deployment with the `dewy container` command.
 
+{% callout type="caution" %}
+Audit tracking is not supported for OCI registries.
+{% /callout %}
+
 ### Supported Registries
 
 Dewy supports all OCI Distribution Specification-compliant registries:

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -78,7 +78,7 @@ jobs:
     test: status == 0
 
 - name: Run server by Github-Releases registry
-  needs: [create_release]
+  needs: [build]
   steps:
   - name: Server test
     uses: embedded
@@ -97,7 +97,7 @@ jobs:
     test: res.code == 0
 
 - name: Run server by AWS S3 registry
-  needs: [create_release]
+  needs: [build]
   steps:
   - name: Server test
     uses: embedded
@@ -116,7 +116,7 @@ jobs:
     test: res.code == 0
 
 - name: Run server by GCloud Storage registry
-  needs: [create_release]
+  needs: [build]
   steps:
   - name: Server test
     uses: embedded
@@ -135,7 +135,7 @@ jobs:
     test: res.code == 0
 
 - name: Run assets by Github-Releases registry
-  needs: [create_release]
+  needs: [build]
   steps:
   - name: Assets test
     uses: embedded
@@ -154,7 +154,7 @@ jobs:
     test: res.code == 0
 
 - name: Run assets by AWS S3 registry
-  needs: [create_release]
+  needs: [build]
   steps:
   - name: Assets test
     uses: embedded
@@ -173,7 +173,7 @@ jobs:
     test: res.code == 0
 
 - name: Run assets by GCloud Storage registry
-  needs: [create_release]
+  needs: [build]
   steps:
   - name: Assets test
     uses: embedded
@@ -208,5 +208,3 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.release.version }}"
     test: res.code == 0
-    echo: |
-      {{ outputs }}

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -43,6 +43,7 @@ jobs:
     - { command: 'container', registry: 'img' }
 
 - name: Create new version
+  id: create_release
   needs: [build]
   steps:
   - name: Create release
@@ -77,7 +78,7 @@ jobs:
     test: status == 0
 
 - name: Run server by Github-Releases registry
-  needs: [build]
+  needs: [create_release]
   steps:
   - name: Server test
     uses: embedded
@@ -96,7 +97,7 @@ jobs:
     test: res.code == 0
 
 - name: Run server by AWS S3 registry
-  needs: [build]
+  needs: [create_release]
   steps:
   - name: Server test
     uses: embedded
@@ -115,7 +116,7 @@ jobs:
     test: res.code == 0
 
 - name: Run server by GCloud Storage registry
-  needs: [build]
+  needs: [create_release]
   steps:
   - name: Server test
     uses: embedded
@@ -134,7 +135,7 @@ jobs:
     test: res.code == 0
 
 - name: Run assets by Github-Releases registry
-  needs: [build]
+  needs: [create_release]
   steps:
   - name: Assets test
     uses: embedded
@@ -153,7 +154,7 @@ jobs:
     test: res.code == 0
 
 - name: Run assets by AWS S3 registry
-  needs: [build]
+  needs: [create_release]
   steps:
   - name: Assets test
     uses: embedded
@@ -172,7 +173,7 @@ jobs:
     test: res.code == 0
 
 - name: Run assets by GCloud Storage registry
-  needs: [build]
+  needs: [create_release]
   steps:
   - name: Assets test
     uses: embedded
@@ -191,7 +192,7 @@ jobs:
     test: res.code == 0
 
 - name: Run container by OCI registry
-  needs: [build]
+  needs: [create_release]
   steps:
   - name: Container test
     uses: embedded

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -24,9 +24,22 @@ jobs:
     uses: hello
     test: vars.google_application_credentials != ''
 
+- name: Generate version
+  id: generate_version
+  needs: [check]
+  steps:
+  - name: Generate version string
+    id: genver
+    uses: hello
+    vars:
+      version: v3.0.0-{{ unixtime() }}
+    outputs:
+      version: vars.version
+    echo: "Generated version: {{ vars.version }}"
+
 - name: Build dewy
   id: build
-  needs: [check]
+  needs: [generate_version]
   steps:
   - name: Go build for {{ vars.command }}-{{ vars.registry }}
     uses: shell
@@ -47,21 +60,16 @@ jobs:
   needs: [build]
   steps:
   - name: Create release
-    id: release
     uses: shell
     with:
       env:
         GH_TOKEN: "{{ vars.github_token }}"
       cmd: |
-        gh release create {{ vars.version }} \
+        gh release create {{ outputs.genver.version }} \
           --repo linyows/dewy-testapp \
-          --title {{ vars.version }} \
+          --title {{ outputs.genver.version }} \
           --notes "End-to-end Testing by Probe"
-    vars:
-      version: v3.0.0-{{ unixtime() }}
     test: status == 0
-    outputs:
-      version: vars.version
     echo: |
       {{res.stdout}}
   - name: Verify release exists
@@ -73,7 +81,7 @@ jobs:
       env:
         GH_TOKEN: "{{ vars.github_token }}"
       cmd: |
-        gh release view {{ outputs.release.version }} \
+        gh release view {{ outputs.genver.version }} \
           --repo linyows/dewy-testapp
     test: status == 0
 
@@ -93,7 +101,7 @@ jobs:
         registry_url: "ghr://linyows/dewy-testapp?pre-release=true"
         port: 8000
         log_level: debug
-        new_version: "{{ outputs.release.version }}"
+        new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
 
 - name: Run server by AWS S3 registry
@@ -112,7 +120,7 @@ jobs:
         registry_url: "s3://ap-northeast-3/dewy-testapp?pre-release=true"
         port: 8001
         log_level: debug
-        new_version: "{{ outputs.release.version }}"
+        new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
 
 - name: Run server by GCloud Storage registry
@@ -131,7 +139,7 @@ jobs:
         registry_url: "gs://dewy-testapp?pre-release=true"
         port: 8002
         log_level: debug
-        new_version: "{{ outputs.release.version }}"
+        new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
 
 - name: Run assets by Github-Releases registry
@@ -150,7 +158,7 @@ jobs:
         registry_url: "ghr://linyows/dewy-testapp?pre-release=true"
         port: 9000
         log_level: debug
-        new_version: "{{ outputs.release.version }}"
+        new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
 
 - name: Run assets by AWS S3 registry
@@ -169,7 +177,7 @@ jobs:
         registry_url: "s3://ap-northeast-3/dewy-testapp?pre-release=true"
         port: 9001
         log_level: debug
-        new_version: "{{ outputs.release.version }}"
+        new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
 
 - name: Run assets by GCloud Storage registry
@@ -188,11 +196,11 @@ jobs:
         registry_url: "gs://dewy-testapp?pre-release=true"
         port: 9002
         log_level: debug
-        new_version: "{{ outputs.release.version }}"
+        new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
 
 - name: Run container by OCI registry
-  needs: [create_release]
+  needs: [build]
   steps:
   - name: Container test
     uses: embedded
@@ -206,5 +214,5 @@ jobs:
         replicas: 3
         container_port: 3333
         log_level: debug
-        new_version: "{{ outputs.release.version }}"
+        new_version: "{{ outputs.genver.version }}"
     test: res.code == 0

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -207,3 +207,5 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.release.version }}"
     test: res.code == 0
+    echo: |
+      {{ outputs }}

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -201,7 +201,7 @@ jobs:
         github_token: "{{ vars.github_token }}"
         registry: img
         registry_url: "img://ghcr.io/linyows/dewy-testapp?pre-release=true"
-        port: 8002
+        port: 7000
         replicas: 3
         container_port: 3333
         log_level: debug

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -40,6 +40,7 @@ jobs:
     - { command: 'assets', registry: 'ghr' }
     - { command: 'assets', registry: 's3' }
     - { command: 'assets', registry: 'gs' }
+    - { command: 'container', registry: 'img' }
 
 - name: Create new version
   needs: [build]
@@ -88,7 +89,7 @@ jobs:
         aws_secret_access_key: "{{ vars.aws_secret_access_key }}"
         google_application_credentials: "{{ vars.google_application_credentials }}"
         registry: ghr
-        registry_url: ghr://linyows/dewy-testapp?pre-release=true
+        registry_url: "ghr://linyows/dewy-testapp?pre-release=true"
         port: 8000
         log_level: debug
         new_version: "{{ outputs.release.version }}"
@@ -107,7 +108,7 @@ jobs:
         aws_secret_access_key: "{{ vars.aws_secret_access_key }}"
         google_application_credentials: "{{ vars.google_application_credentials }}"
         registry: s3
-        registry_url: s3://ap-northeast-3/dewy-testapp?pre-release=true
+        registry_url: "s3://ap-northeast-3/dewy-testapp?pre-release=true"
         port: 8001
         log_level: debug
         new_version: "{{ outputs.release.version }}"
@@ -126,7 +127,7 @@ jobs:
         aws_secret_access_key: "{{ vars.aws_secret_access_key }}"
         google_application_credentials: "{{ vars.google_application_credentials }}"
         registry: gs
-        registry_url: gs://dewy-testapp?pre-release=true
+        registry_url: "gs://dewy-testapp?pre-release=true"
         port: 8002
         log_level: debug
         new_version: "{{ outputs.release.version }}"
@@ -145,7 +146,7 @@ jobs:
         aws_secret_access_key: "{{ vars.aws_secret_access_key }}"
         google_application_credentials: "{{ vars.google_application_credentials }}"
         registry: ghr
-        registry_url: ghr://linyows/dewy-testapp?pre-release=true
+        registry_url: "ghr://linyows/dewy-testapp?pre-release=true"
         port: 9000
         log_level: debug
         new_version: "{{ outputs.release.version }}"
@@ -164,7 +165,7 @@ jobs:
         aws_secret_access_key: "{{ vars.aws_secret_access_key }}"
         google_application_credentials: "{{ vars.google_application_credentials }}"
         registry: s3
-        registry_url: s3://ap-northeast-3/dewy-testapp?pre-release=true
+        registry_url: "s3://ap-northeast-3/dewy-testapp?pre-release=true"
         port: 9001
         log_level: debug
         new_version: "{{ outputs.release.version }}"
@@ -183,8 +184,26 @@ jobs:
         aws_secret_access_key: "{{ vars.aws_secret_access_key }}"
         google_application_credentials: "{{ vars.google_application_credentials }}"
         registry: gs
-        registry_url: gs://dewy-testapp?pre-release=true
+        registry_url: "gs://dewy-testapp?pre-release=true"
         port: 9002
+        log_level: debug
+        new_version: "{{ outputs.release.version }}"
+    test: res.code == 0
+
+- name: Run container by OCI registry
+  needs: [build]
+  steps:
+  - name: Container test
+    uses: embedded
+    with:
+      path: ./testdata/jobs/container.yml
+      vars:
+        github_token: "{{ vars.github_token }}"
+        registry: img
+        registry_url: "img://ghcr.io/linyows/dewy-testapp?pre-release=true"
+        port: 8002
+        replicas: 3
+        container_port: 3333
         log_level: debug
         new_version: "{{ outputs.release.version }}"
     test: res.code == 0

--- a/testdata/jobs/assets.yml
+++ b/testdata/jobs/assets.yml
@@ -32,7 +32,6 @@ steps:
     cmd: |
       if [ -f "{{ outputs.server.log }}" ]; then
         grep "Download notification" "{{ outputs.server.log }}" | \
-          awk '{print $6}' | \
           grep -q "{{ replace(vars.new_version, 'v', '') }}" && exit 0
       fi
       exit 1
@@ -86,7 +85,6 @@ steps:
   with:
     cmd: |
       grep 'Download notification' {{ outputs.server.log }} | \
-        awk '{print $6}' | \
         grep {{ replace(vars.new_version, 'v', '') }}
   test: status == 0
   outputs:

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -64,8 +64,8 @@ steps:
   uses: shell
   with:
     cmd: |
-      grep -c 'Starting new container' {{ outputs.container.log }} | \
-      grep -v {{ vars.new_version }} | tr -d '\n'
+      grep 'Starting new container' {{ outputs.container.log }} | \
+        grep -vc {{ vars.new_version }} | tr -d '\n'
   test: res.stdout == "3"
   outputs:
     ok: res.stdout == "3"
@@ -75,8 +75,8 @@ steps:
   uses: shell
   with:
     cmd: |
-      grep -c 'Starting new container' {{ outputs.container.log }} | \
-      grep -c "{{ vars.new_version }}" | tr -d '\n'
+      grep 'Starting new container' {{ outputs.container.log }} | \
+        grep -c {{ vars.new_version }} | tr -d '\n'
   test: res.stdout == "3"
   outputs:
     ok: res.stdout == "3"

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -23,11 +23,6 @@ steps:
     PID: {{ res.pid }}
     Log: {{ res.log }}
 
-- name: Debug vars
-  uses: hello
-  echo: |
-    vars: {{ vars }}
-
 - name: Wait for new version to start
   uses: shell
   retry:

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -1,0 +1,89 @@
+name: Container Test
+
+steps:
+- name: Start dewy
+  id: container
+  uses: shell
+  with:
+    workdir: ./testdata/container/{{ vars.registry }}
+    background: true
+    env:
+      GITHUB_TOKEN: "{{ vars.github_token }}"
+    cmd: |
+      ./dewy container -p {{ vars.port }} -l {{ vars.log_level }} \
+      --registry "{{ vars.registry_url }}" \
+      --health-path /health \
+      --container-port {{ vars.container_port }} \
+      --replicas {{ vars.replicas }}
+  test: status == -1
+  outputs:
+    pid: res.pid
+    log: res.log
+  echo: |
+    PID: {{ res.pid }}
+    Log: {{ res.log }}
+
+- name: Wait for new version to start
+  uses: shell
+  retry:
+    max_attempts: 60
+    interval: 5s
+  with:
+    cmd: |
+      if [ -f "{{ outputs.container.log }}" ]; then
+        grep "Starting new container" "{{ outputs.container.log }}" | \
+          grep -q "{{ vars.new_version }}" && exit 0
+      fi
+      exit 1
+  test: status == 0
+
+- name: Wait for stabilization
+  wait: 30s
+  uses: shell
+  with:
+    cmd: "echo 'Waiting for system stabilization after new version detection'"
+  test: status == 0
+
+- name: Stop dewy
+  uses: shell
+  with: # Use Process Group ID
+    cmd: "kill -TERM -{{ outputs.container.pid }}"
+  test: status == 0
+
+- name: Verify no error
+  id: noerr
+  uses: shell
+  with:
+    cmd: "grep -i error {{ outputs.container.log }}"
+  test: status == 1
+  outputs:
+    ok: status == 1
+
+- name: Verify current 3 containers creates
+  id: cver
+  uses: shell
+  with:
+    cmd: |
+      grep -c 'Starting new container' {{ outputs.container.log }} | \
+      grep -v {{ vars.new_version }} | tr -d '\n'
+  test: res.stdout == "3"
+  outputs:
+    ok: res.stdout == "3"
+
+- name: Verify new 3 containers creates
+  id: nver
+  uses: shell
+  with:
+    cmd: |
+      grep -c 'Starting new container' {{ outputs.container.log }} | \
+      grep -c "{{ vars.new_version }}" | tr -d '\n'
+  test: res.stdout == "3"
+  outputs:
+    ok: res.stdout == "3"
+
+- name: Show log
+  skipif: outputs.noerr.ok && outputs.cver.ok && outputs.nver.ok
+  uses: shell
+  with:
+    cmd: "cat {{ outputs.container.log }}"
+  echo: "{{ res.stdout }}"

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -65,7 +65,7 @@ steps:
   with:
     cmd: |
       grep 'Starting new container' {{ outputs.container.log }} | \
-        grep -vc {{ vars.new_version }} | tr -d '\n'
+        grep -vc {{ replace(vars.new_version, 'v', '') }} | tr -d '\n'
   test: res.stdout == "3"
   outputs:
     ok: res.stdout == "3"
@@ -76,7 +76,7 @@ steps:
   with:
     cmd: |
       grep 'Starting new container' {{ outputs.container.log }} | \
-        grep -c {{ vars.new_version }} | tr -d '\n'
+        grep -c {{ replace(vars.new_version, 'v', '') }} | tr -d '\n'
   test: res.stdout == "3"
   outputs:
     ok: res.stdout == "3"

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -23,6 +23,11 @@ steps:
     PID: {{ res.pid }}
     Log: {{ res.log }}
 
+- name: Debug vars
+  uses: hello
+  echo: |
+    vars: {{ vars }}
+
 - name: Wait for new version to start
   uses: shell
   retry:

--- a/testdata/jobs/server.yml
+++ b/testdata/jobs/server.yml
@@ -33,7 +33,6 @@ steps:
     cmd: |
       if [ -f "{{ outputs.server.log }}" ]; then
         grep "starting version" "{{ outputs.server.log }}" | \
-          awk '{print $6}' | \
           grep -q "{{ replace(vars.new_version, 'v', '') }}" && exit 0
       fi
       exit 1
@@ -87,7 +86,6 @@ steps:
   with:
     cmd: |
       grep 'starting version' {{ outputs.server.log }} | \
-        awk '{print $6}' | \
         grep {{ replace(vars.new_version, 'v', '') }}
   test: status == 0
   outputs:


### PR DESCRIPTION
## Summary
- Add comprehensive E2E test for container command using OCI registry (img://)
- Improve logging by adding version tracking for server restart/start and container deployment events
- Add Makefile target for manual container command testing

## Changes
- **E2E Test**: New `testdata/jobs/container.yml` for automated container command testing
- **Version Tracking**: Added `cVer` field to track currently deployed version in logs
- **Enhanced Logging**: Server restart/start and container deployment logs now include version information
- **Test Infrastructure**: Added container test job to `testdata/e2e-test.yml`
- **Makefile**: Added `container` target for easy manual testing
- **.gitignore**: Added `/testdata/container` to exclude binaries from version control

## Test Plan
- ✅ E2E test verifies container deployment with OCI registry
- ✅ Test confirms 3 replicas are created for both current and new versions
- ✅ Test validates no errors occur during deployment
- ✅ Logs include version information for better debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)