### PR TITLE
Add auto-label workflow for pull requests

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,19 @@
+name: Auto Label Pull Requests
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Add slack-notify Label
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
+        with:
+          labels: slack-notify


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow to automatically add the `slack-notify` label to pull requests when they are opened or reopened. This enables automated Slack notifications for new PRs while excluding dependabot updates.

## Implementation

### Workflow Configuration
- **File**: `.github/workflows/auto-label.yml`
- **Trigger**: `pull_request` events (types: opened, reopened)
- **Condition**: Skips PRs created by `dependabot[bot]`
- **Action**: Uses `actions-ecosystem/action-add-labels@v1.1.3` for simplicity

### Permissions
- `contents: read` - Read repository contents
- `pull-requests: write` - Add labels to PRs

## Features

✅ Automatically labels new PRs for Slack notification
✅ Excludes dependabot PRs to reduce noise  
✅ Uses minimal required permissions
✅ Simple and maintainable implementation
✅ Follows existing workflow conventions (SHA pinning, naming)

## Testing

This workflow will be tested automatically when this PR is opened - it should receive the `slack-notify` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)