### PR TITLE
Make red color more orange in Slack notification

### DIFF
--- a/notifier/slack.go
+++ b/notifier/slack.go
@@ -210,8 +210,8 @@ func (s *Slack) genColor() string {
 	// Avoid red colors that might indicate failure
 	if isRed(r, g, b) {
 		h, sat, l := rgbToHSL(r, g, b)
-		// Rotate hue by +30 degrees to shift away from red
-		h = h + 30.0
+		// Rotate hue by +35 degrees to shift away from red
+		h = h + 35.0
 		if h >= 360.0 {
 			h -= 360.0
 		}


### PR DESCRIPTION
Color [#CC3300](https://www.color-hex.com/color/cc3300) to [#CC4D00](https://www.color-hex.com/color/cc4d00).