### PR TITLE
Fix go install command

### DIFF
--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -77,7 +77,7 @@ sudo mv dewy /usr/local/bin/
 
 ```bash
 # Install directly from latest main branch
-go install github.com/linyows/dewy@latest
+go install github.com/linyows/dewy/cmd/dewy@latest
 ```
 
 ### 3. Provisioning Tools

--- a/docs/pages/ja/installation.md
+++ b/docs/pages/ja/installation.md
@@ -77,7 +77,7 @@ sudo mv dewy /usr/local/bin/
 
 ```bash
 # 最新のmainブランチから直接インストール
-go install github.com/linyows/dewy@latest
+go install github.com/linyows/dewy/cmd/dewy@latest
 ```
 
 ### 3. プロビジョニングツール


### PR DESCRIPTION
Hi, thank you for developing this tool.

Running `go install github.com/linyows/dewy@latest` results in the following error:

```sh
package github.com/linyows/dewy is not a main package
```

I was able to install it successfully using `go install github.com/linyows/dewy/cmd/dewy@latest`.

Just a small doc fix.