### PR TITLE
feat(container): support multiple port TCP proxy

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -40,7 +40,7 @@ jobs:
       uses: linyows/probe-action@0164e23555aacbaaea03169102262dafeb1ff631 # v1
       with:
         path: testdata/e2e-test.yml
-        version: v0.23.0
+        version: v1.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -8,6 +8,13 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'testdata/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/container/docker.go
+++ b/container/docker.go
@@ -457,13 +457,14 @@ func (d *Docker) GetMappedPort(ctx context.Context, containerID string, containe
 	return hostPort, nil
 }
 
-// GetRunningContainerWithImage checks if a container is running with the specified image.
+// GetRunningContainerWithImage checks if a container is running with the specified image and app name.
 // It returns the container ID if found, or an empty string if not found.
-func (d *Docker) GetRunningContainerWithImage(ctx context.Context, imageRef string) (string, error) {
-	// Get list of running containers with the specified ancestor (image)
-	// Format: docker ps --filter ancestor=<image> --filter status=running --format "{{.ID}}"
+func (d *Docker) GetRunningContainerWithImage(ctx context.Context, imageRef, appName string) (string, error) {
+	// Get list of running containers with the specified ancestor (image) and app label
+	// Format: docker ps --filter ancestor=<image> --filter label=dewy.app=<appName> --filter status=running --format "{{.ID}}"
 	output, err := d.execCommandOutput(ctx, "ps",
 		"--filter", fmt.Sprintf("ancestor=%s", imageRef),
+		"--filter", fmt.Sprintf("label=dewy.app=%s", appName),
 		"--filter", "status=running",
 		"--format", "{{.ID}}")
 

--- a/container/podman.go
+++ b/container/podman.go
@@ -415,13 +415,14 @@ func (p *Podman) GetMappedPort(ctx context.Context, containerID string, containe
 	return hostPort, nil
 }
 
-// GetRunningContainerWithImage checks if a container is running with the specified image.
+// GetRunningContainerWithImage checks if a container is running with the specified image and app name.
 // It returns the container ID if found, or an empty string if not found.
-func (p *Podman) GetRunningContainerWithImage(ctx context.Context, imageRef string) (string, error) {
-	// Get list of running containers with the specified ancestor (image)
-	// Format: podman ps --filter ancestor=<image> --filter status=running --format "{{.ID}}"
+func (p *Podman) GetRunningContainerWithImage(ctx context.Context, imageRef, appName string) (string, error) {
+	// Get list of running containers with the specified ancestor (image) and app label
+	// Format: podman ps --filter ancestor=<image> --filter label=dewy.app=<appName> --filter status=running --format "{{.ID}}"
 	output, err := p.execCommandOutput(ctx, "ps",
 		"--filter", fmt.Sprintf("ancestor=%s", imageRef),
+		"--filter", fmt.Sprintf("label=dewy.app=%s", appName),
 		"--filter", "status=running",
 		"--format", "{{.ID}}")
 

--- a/dewy.go
+++ b/dewy.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -57,14 +58,29 @@ type Dewy struct {
 	job              *scheduler.Job
 	notifier         notifier.Notifier
 	logger           *logging.Logger
-	proxyServer      *http.Server
-	proxyBackends    []*url.URL // Multiple backends for load balancing
-	proxyIndex       int        // Round-robin counter
+	tcpProxies       map[int]*tcpProxy // TCP proxies keyed by proxy port
 	proxyMutex       sync.RWMutex
 	adminServer      *http.Server // Admin API server for CLI communication
 	containerRuntime container.Runtime
 	cVer             string // Current deployed version (tag)
 	sync.RWMutex
+}
+
+// tcpProxy manages a TCP proxy for a single port.
+type tcpProxy struct {
+	proxyPort    int
+	listener     net.Listener
+	backends     []tcpBackend
+	backendIndex uint64 // Atomic counter for round-robin
+	mu           sync.RWMutex
+	done         chan struct{}
+	logger       *logging.Logger
+}
+
+// tcpBackend represents a backend server.
+type tcpBackend struct {
+	host string
+	port int
 }
 
 // New returns Dewy.
@@ -1051,153 +1067,258 @@ func (d *Dewy) rollbackContainers(ctx context.Context, dockerRuntime *container.
 	}
 }
 
-// startProxy starts the built-in reverse proxy HTTP server.
+// startProxy starts TCP proxies for all configured port mappings.
 func (d *Dewy) startProxy(ctx context.Context) error {
-	// Create a reverse proxy handler with round-robin load balancing
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		d.proxyMutex.Lock()
-		backends := d.proxyBackends
-		if len(backends) == 0 {
-			d.proxyMutex.Unlock()
-			http.Error(w, "Service Unavailable - No backend configured", http.StatusServiceUnavailable)
-			d.logger.Debug("Proxy request rejected - no backend configured",
-				slog.String("method", r.Method),
-				slog.String("path", r.URL.Path))
-			return
-		}
-
-		// Round-robin: select next backend
-		backend := backends[d.proxyIndex%len(backends)]
-		d.proxyIndex++
-		d.proxyMutex.Unlock()
-
-		// Create reverse proxy for selected backend
-		proxy := httputil.NewSingleHostReverseProxy(backend)
-
-		// Custom error handler
-		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-			d.logger.Error("Proxy error",
-				slog.String("backend", backend.String()),
-				slog.String("method", r.Method),
-				slog.String("path", r.URL.Path),
-				slog.String("error", err.Error()))
-			http.Error(w, "Bad Gateway", http.StatusBadGateway)
-		}
-
-		// Proxy the request
-		d.logger.Debug("Proxying request",
-			slog.String("backend", backend.String()),
-			slog.String("method", r.Method),
-			slog.String("path", r.URL.Path))
-		proxy.ServeHTTP(w, r)
-	})
-
-	// Create HTTP server using the first proxy port from port mappings
 	if len(d.config.Container.PortMappings) == 0 {
 		return fmt.Errorf("no port mappings configured for proxy")
 	}
-	proxyPort := d.config.Container.PortMappings[0].ProxyPort
-	addr := fmt.Sprintf(":%d", proxyPort)
-	d.proxyServer = &http.Server{
-		Addr:              addr,
-		Handler:           handler,
-		ReadHeaderTimeout: 5 * time.Second, // For slowloris attack
-	}
-
-	// Start server in background
-	go func() {
-		d.logger.Info("Starting built-in reverse proxy",
-			slog.String("address", addr))
-
-		if err := d.proxyServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			d.logger.Error("Proxy server error", slog.String("error", err.Error()))
-		}
-	}()
-
-	// Wait a moment to ensure server starts
-	time.Sleep(100 * time.Millisecond)
-
-	// Verify server is listening
-	conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
-	if err != nil {
-		return fmt.Errorf("proxy server failed to start: %w", err)
-	}
-	conn.Close()
-
-	d.logger.Info("Built-in reverse proxy started successfully",
-		slog.String("listen", addr))
-
-	return nil
-}
-
-// addProxyBackend adds a new backend to the load balancer pool.
-// For multi-port support, proxyPort specifies which proxy port this backend serves.
-// Currently only single proxy port is supported, so proxyPort is logged but not used.
-func (d *Dewy) addProxyBackend(host string, port int, proxyPort int) error {
-	backend, err := url.Parse(fmt.Sprintf("http://%s:%d", host, port))
-	if err != nil {
-		return fmt.Errorf("failed to parse backend URL: %w", err)
-	}
 
 	d.proxyMutex.Lock()
-	d.proxyBackends = append(d.proxyBackends, backend)
+	d.tcpProxies = make(map[int]*tcpProxy)
 	d.proxyMutex.Unlock()
 
-	d.logger.Info("Proxy backend added",
-		slog.String("backend", backend.String()),
-		slog.Int("proxy_port", proxyPort),
-		slog.Int("total_backends", len(d.proxyBackends)))
+	// Start a TCP proxy for each port mapping
+	for _, mapping := range d.config.Container.PortMappings {
+		proxy, err := newTCPProxy(mapping.ProxyPort, d.logger)
+		if err != nil {
+			// Clean up already started proxies
+			d.stopProxy(ctx)
+			return fmt.Errorf("failed to start proxy on port %d: %w", mapping.ProxyPort, err)
+		}
+
+		d.proxyMutex.Lock()
+		d.tcpProxies[mapping.ProxyPort] = proxy
+		d.proxyMutex.Unlock()
+
+		d.logger.Info("TCP proxy started",
+			slog.Int("proxy_port", mapping.ProxyPort))
+	}
+
+	d.logger.Info("All TCP proxies started successfully",
+		slog.Int("count", len(d.config.Container.PortMappings)))
 
 	return nil
 }
 
-// removeProxyBackend removes a backend from the load balancer pool.
-// For multi-port support, proxyPort specifies which proxy port this backend serves.
-// Currently only single proxy port is supported, so proxyPort is logged but not used.
-func (d *Dewy) removeProxyBackend(host string, port int, proxyPort int) error {
-	targetURL := fmt.Sprintf("http://%s:%d", host, port)
+// newTCPProxy creates and starts a new TCP proxy on the specified port.
+func newTCPProxy(port int, logger *logging.Logger) (*tcpProxy, error) {
+	addr := fmt.Sprintf(":%d", port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
+	}
 
+	proxy := &tcpProxy{
+		proxyPort: port,
+		listener:  listener,
+		backends:  make([]tcpBackend, 0),
+		done:      make(chan struct{}),
+		logger:    logger,
+	}
+
+	go proxy.acceptLoop()
+
+	return proxy, nil
+}
+
+// acceptLoop accepts incoming connections and proxies them to backends.
+func (p *tcpProxy) acceptLoop() {
+	for {
+		select {
+		case <-p.done:
+			return
+		default:
+		}
+
+		conn, err := p.listener.Accept()
+		if err != nil {
+			select {
+			case <-p.done:
+				return
+			default:
+				p.logger.Debug("Accept error",
+					slog.Int("proxy_port", p.proxyPort),
+					slog.String("error", err.Error()))
+				continue
+			}
+		}
+
+		go p.handleConnection(conn)
+	}
+}
+
+// handleConnection proxies a single connection to a backend.
+func (p *tcpProxy) handleConnection(clientConn net.Conn) {
+	defer clientConn.Close()
+
+	// Get backend using round-robin
+	backend, ok := p.getNextBackend()
+	if !ok {
+		p.logger.Debug("No backend available",
+			slog.Int("proxy_port", p.proxyPort))
+		return
+	}
+
+	// Connect to backend
+	backendAddr := fmt.Sprintf("%s:%d", backend.host, backend.port)
+	backendConn, err := net.DialTimeout("tcp", backendAddr, 5*time.Second)
+	if err != nil {
+		p.logger.Error("Failed to connect to backend",
+			slog.Int("proxy_port", p.proxyPort),
+			slog.String("backend", backendAddr),
+			slog.String("error", err.Error()))
+		return
+	}
+	defer backendConn.Close()
+
+	p.logger.Debug("Proxying connection",
+		slog.Int("proxy_port", p.proxyPort),
+		slog.String("backend", backendAddr),
+		slog.String("client", clientConn.RemoteAddr().String()))
+
+	// Bidirectional copy
+	done := make(chan struct{}, 2)
+
+	go func() {
+		io.Copy(backendConn, clientConn)
+		done <- struct{}{}
+	}()
+
+	go func() {
+		io.Copy(clientConn, backendConn)
+		done <- struct{}{}
+	}()
+
+	// Wait for either direction to complete
+	<-done
+}
+
+// getNextBackend returns the next backend using round-robin.
+func (p *tcpProxy) getNextBackend() (tcpBackend, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if len(p.backends) == 0 {
+		return tcpBackend{}, false
+	}
+
+	index := atomic.AddUint64(&p.backendIndex, 1) - 1
+	return p.backends[index%uint64(len(p.backends))], true
+}
+
+// addBackend adds a backend to this proxy.
+func (p *tcpProxy) addBackend(host string, port int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.backends = append(p.backends, tcpBackend{host: host, port: port})
+	p.logger.Info("Backend added to TCP proxy",
+		slog.Int("proxy_port", p.proxyPort),
+		slog.String("backend_host", host),
+		slog.Int("backend_port", port),
+		slog.Int("total_backends", len(p.backends)))
+}
+
+// removeBackend removes a backend from this proxy.
+func (p *tcpProxy) removeBackend(host string, port int) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for i, b := range p.backends {
+		if b.host == host && b.port == port {
+			p.backends = append(p.backends[:i], p.backends[i+1:]...)
+			p.logger.Info("Backend removed from TCP proxy",
+				slog.Int("proxy_port", p.proxyPort),
+				slog.String("backend_host", host),
+				slog.Int("backend_port", port),
+				slog.Int("remaining_backends", len(p.backends)))
+			return true
+		}
+	}
+	return false
+}
+
+// stop stops the TCP proxy.
+func (p *tcpProxy) stop() error {
+	close(p.done)
+	return p.listener.Close()
+}
+
+// backendCount returns the number of backends.
+func (p *tcpProxy) backendCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.backends)
+}
+
+// addProxyBackend adds a new backend to the appropriate TCP proxy.
+func (d *Dewy) addProxyBackend(host string, port int, proxyPort int) error {
+	d.proxyMutex.RLock()
+	proxy, exists := d.tcpProxies[proxyPort]
+	d.proxyMutex.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("no proxy configured for port %d", proxyPort)
+	}
+
+	proxy.addBackend(host, port)
+	return nil
+}
+
+// removeProxyBackend removes a backend from the appropriate TCP proxy.
+func (d *Dewy) removeProxyBackend(host string, port int, proxyPort int) error {
+	d.proxyMutex.RLock()
+	proxy, exists := d.tcpProxies[proxyPort]
+	d.proxyMutex.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("no proxy configured for port %d", proxyPort)
+	}
+
+	if !proxy.removeBackend(host, port) {
+		return fmt.Errorf("backend %s:%d not found for proxy port %d", host, port, proxyPort)
+	}
+	return nil
+}
+
+// stopProxy gracefully shuts down all TCP proxies.
+func (d *Dewy) stopProxy(ctx context.Context) error {
 	d.proxyMutex.Lock()
 	defer d.proxyMutex.Unlock()
 
-	newBackends := make([]*url.URL, 0, len(d.proxyBackends))
-	for _, backend := range d.proxyBackends {
-		if backend.String() != targetURL {
-			newBackends = append(newBackends, backend)
-		}
-	}
-
-	if len(newBackends) == len(d.proxyBackends) {
-		return fmt.Errorf("backend not found: %s", targetURL)
-	}
-
-	d.proxyBackends = newBackends
-	d.proxyIndex = 0 // Reset index
-
-	d.logger.Info("Proxy backend removed",
-		slog.String("backend", targetURL),
-		slog.Int("remaining_backends", len(d.proxyBackends)))
-
-	return nil
-}
-
-// stopProxy gracefully shuts down the reverse proxy server.
-func (d *Dewy) stopProxy(ctx context.Context) error {
-	if d.proxyServer == nil {
+	if d.tcpProxies == nil {
 		return nil
 	}
 
-	d.logger.Info("Stopping reverse proxy")
+	d.logger.Info("Stopping TCP proxies", slog.Int("count", len(d.tcpProxies)))
 
-	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	if err := d.proxyServer.Shutdown(shutdownCtx); err != nil {
-		return fmt.Errorf("failed to shutdown proxy: %w", err)
+	var errs []error
+	for port, proxy := range d.tcpProxies {
+		if err := proxy.stop(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to stop proxy on port %d: %w", port, err))
+		}
 	}
 
-	d.logger.Info("Reverse proxy stopped")
+	d.tcpProxies = nil
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	d.logger.Info("All TCP proxies stopped")
 	return nil
+}
+
+// totalProxyBackends returns the total number of backends across all TCP proxies.
+func (d *Dewy) totalProxyBackends() int {
+	d.proxyMutex.RLock()
+	defer d.proxyMutex.RUnlock()
+
+	total := 0
+	for _, proxy := range d.tcpProxies {
+		total += proxy.backendCount()
+	}
+	return total
 }
 
 // stopManagedContainers stops all containers managed by dewy.
@@ -1401,13 +1522,16 @@ func (d *Dewy) handleGetStatus(w http.ResponseWriter, r *http.Request) {
 	d.RLock()
 	defer d.RUnlock()
 
+	// Count total backends across all proxies
+	totalBackends := d.totalProxyBackends()
+
 	// Return JSON response
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"name":            d.config.Container.Name,
 		"command":         d.config.Command,
 		"current_version": d.cVer,
-		"proxy_backends":  len(d.proxyBackends),
+		"proxy_backends":  totalBackends,
 		"is_running":      d.isServerRunning,
 	}); err != nil {
 		d.logger.Error("Failed to encode response",

--- a/dewy_test.go
+++ b/dewy_test.go
@@ -1125,15 +1125,17 @@ func TestTCPProxy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create TCP proxy: %v", err)
 		}
-		defer proxy.stop()
+		defer func() { _ = proxy.stop() }()
 
 		if proxy.listener == nil {
 			t.Error("Expected listener to be initialized")
 		}
 		if proxy.proxyPort == 0 {
 			// Port should be assigned even when requesting 0
-			addr := proxy.listener.Addr().(*net.TCPAddr)
-			if addr.Port == 0 {
+			tcpAddr, ok := proxy.listener.Addr().(*net.TCPAddr)
+			if !ok {
+				t.Error("Expected TCP address")
+			} else if tcpAddr.Port == 0 {
 				t.Error("Expected port to be assigned")
 			}
 		}
@@ -1145,7 +1147,7 @@ func TestTCPProxy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create TCP proxy: %v", err)
 		}
-		defer proxy.stop()
+		defer func() { _ = proxy.stop() }()
 
 		// Add backends
 		proxy.addBackend("localhost", 8080)
@@ -1178,7 +1180,7 @@ func TestTCPProxy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create TCP proxy: %v", err)
 		}
-		defer proxy.stop()
+		defer func() { _ = proxy.stop() }()
 
 		proxy.addBackend("host1", 8080)
 		proxy.addBackend("host2", 8081)
@@ -1209,7 +1211,7 @@ func TestTCPProxy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create TCP proxy: %v", err)
 		}
-		defer proxy.stop()
+		defer func() { _ = proxy.stop() }()
 
 		_, ok := proxy.getNextBackend()
 		if ok {
@@ -1248,7 +1250,7 @@ func TestMultiPortTCPProxy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to start proxies: %v", err)
 	}
-	defer dewy.stopProxy(ctx)
+	defer func() { _ = dewy.stopProxy(ctx) }()
 
 	// Check that both proxies are running
 	dewy.proxyMutex.RLock()

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -215,3 +215,22 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+
+- name: Run container with multiple ports by OCI registry
+  needs: [build]
+  steps:
+  - name: Container multi-port test
+    uses: embedded
+    with:
+      path: ./testdata/jobs/container-multiport.yml
+      vars:
+        github_token: "{{ vars.github_token }}"
+        registry: img
+        registry_url: "img://ghcr.io/linyows/dewy-testapp?pre-release=true"
+        port1: 7100
+        port2: 7101
+        container_port: 3333
+        replicas: 2
+        log_level: debug
+        new_version: "{{ outputs.genver.version }}"
+    test: res.code == 0

--- a/testdata/e2e-test.yml
+++ b/testdata/e2e-test.yml
@@ -54,6 +54,7 @@ jobs:
     - { command: 'assets', registry: 's3' }
     - { command: 'assets', registry: 'gs' }
     - { command: 'container', registry: 'img' }
+    - { command: 'container-multiport', registry: 'img' }
 
 - name: Create new version
   id: create_release
@@ -103,6 +104,7 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m
 
 - name: Run server by AWS S3 registry
   needs: [build]
@@ -122,6 +124,7 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m
 
 - name: Run server by GCloud Storage registry
   needs: [build]
@@ -141,6 +144,7 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m
 
 - name: Run assets by Github-Releases registry
   needs: [build]
@@ -160,6 +164,7 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m
 
 - name: Run assets by AWS S3 registry
   needs: [build]
@@ -179,6 +184,7 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m
 
 - name: Run assets by GCloud Storage registry
   needs: [build]
@@ -198,6 +204,7 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m
 
 - name: Run container by OCI registry
   needs: [build]
@@ -215,6 +222,7 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m
 
 - name: Run container with multiple ports by OCI registry
   needs: [build]
@@ -234,3 +242,4 @@ jobs:
         log_level: debug
         new_version: "{{ outputs.genver.version }}"
     test: res.code == 0
+    timeout: 15m

--- a/testdata/jobs/container-multiport.yml
+++ b/testdata/jobs/container-multiport.yml
@@ -11,6 +11,7 @@ steps:
       GITHUB_TOKEN: "{{ vars.github_token }}"
     cmd: |
       ./dewy container \
+      --name dewy-testapp-multiport \
       -p {{ vars.port1 }}:{{ vars.container_port }} \
       -p {{ vars.port2 }}:{{ vars.container_port }} \
       -l {{ vars.log_level }} \

--- a/testdata/jobs/container-multiport.yml
+++ b/testdata/jobs/container-multiport.yml
@@ -1,0 +1,159 @@
+name: Container Multi-Port Test
+
+steps:
+- name: Start dewy with multiple ports
+  id: container
+  uses: shell
+  with:
+    workdir: ./testdata/container/{{ vars.registry }}
+    background: true
+    env:
+      GITHUB_TOKEN: "{{ vars.github_token }}"
+    cmd: |
+      ./dewy container \
+      -p {{ vars.port1 }}:{{ vars.container_port }} \
+      -p {{ vars.port2 }}:{{ vars.container_port }} \
+      -l {{ vars.log_level }} \
+      --registry "{{ vars.registry_url }}" \
+      --health-path /health \
+      --replicas {{ vars.replicas }}
+  test: status == -1
+  outputs:
+    pid: res.pid
+    log: res.log
+  echo: |
+    PID: {{ res.pid }}
+    Log: {{ res.log }}
+
+- name: Wait for new version to start
+  uses: shell
+  retry:
+    max_attempts: 120
+    interval: 5s
+  with:
+    cmd: |
+      if [ -f "{{ outputs.container.log }}" ]; then
+        grep "Starting new container" "{{ outputs.container.log }}" | \
+          grep -q "{{ vars.new_version }}" && exit 0
+      fi
+      exit 1
+  test: status == 0
+
+- name: Wait for stabilization
+  wait: 60s
+  uses: shell
+  with:
+    cmd: "echo 'Waiting for system stabilization after new version detection'"
+  test: status == 0
+
+- name: Verify TCP proxy started on port1
+  id: proxy1
+  uses: shell
+  with:
+    cmd: |
+      grep 'TCP proxy started' {{ outputs.container.log }} | \
+        grep -c 'proxy_port={{ vars.port1 }}' | tr -d '\n'
+  test: res.stdout == "1"
+  outputs:
+    ok: res.stdout == "1"
+
+- name: Verify TCP proxy started on port2
+  id: proxy2
+  uses: shell
+  with:
+    cmd: |
+      grep 'TCP proxy started' {{ outputs.container.log }} | \
+        grep -c 'proxy_port={{ vars.port2 }}' | tr -d '\n'
+  test: res.stdout == "1"
+  outputs:
+    ok: res.stdout == "1"
+
+- name: Verify all TCP proxies started
+  id: allproxies
+  uses: shell
+  with:
+    cmd: |
+      grep 'All TCP proxies started successfully' {{ outputs.container.log }} | \
+        grep -c 'count=2' | tr -d '\n'
+  test: res.stdout == "1"
+  outputs:
+    ok: res.stdout == "1"
+
+- name: Verify backends added to port1
+  id: backend1
+  uses: shell
+  with:
+    cmd: |
+      grep 'Backend added to TCP proxy' {{ outputs.container.log }} | \
+        grep -c 'proxy_port={{ vars.port1 }}' | tr -d '\n'
+  test: int(res.stdout) >= int(vars.replicas)
+  outputs:
+    ok: int(res.stdout) >= int(vars.replicas)
+
+- name: Verify backends added to port2
+  id: backend2
+  uses: shell
+  with:
+    cmd: |
+      grep 'Backend added to TCP proxy' {{ outputs.container.log }} | \
+        grep -c 'proxy_port={{ vars.port2 }}' | tr -d '\n'
+  test: int(res.stdout) >= int(vars.replicas)
+  outputs:
+    ok: int(res.stdout) >= int(vars.replicas)
+
+- name: Test connection to port1
+  id: conn1
+  uses: shell
+  retry:
+    max_attempts: 5
+    interval: 2s
+  with:
+    cmd: "curl -s -o /dev/null -w '%{http_code}' http://localhost:{{ vars.port1 }}/health"
+  test: res.stdout == "200"
+  outputs:
+    ok: res.stdout == "200"
+
+- name: Test connection to port2
+  id: conn2
+  uses: shell
+  retry:
+    max_attempts: 5
+    interval: 2s
+  with:
+    cmd: "curl -s -o /dev/null -w '%{http_code}' http://localhost:{{ vars.port2 }}/health"
+  test: res.stdout == "200"
+  outputs:
+    ok: res.stdout == "200"
+
+- name: Stop dewy
+  uses: shell
+  with: # Use Process Group ID
+    cmd: "kill -TERM -{{ outputs.container.pid }}"
+  test: status == 0
+
+- name: Verify no error
+  id: noerr
+  uses: shell
+  with:
+    cmd: "grep -i error {{ outputs.container.log }}"
+  test: status == 1
+  outputs:
+    ok: status == 1
+
+- name: Verify new containers created
+  id: nver
+  uses: shell
+  with:
+    cmd: |
+      grep 'Starting new container' {{ outputs.container.log }} | \
+        grep -c {{ vars.new_version }} | tr -d '\n'
+  test: res.stdout == "{{ vars.replicas }}"
+  outputs:
+    ok: res.stdout == "{{ vars.replicas }}"
+
+- name: Show log
+  skipif: outputs.noerr.ok && outputs.proxy1.ok && outputs.proxy2.ok && outputs.allproxies.ok && outputs.backend1.ok && outputs.backend2.ok && outputs.conn1.ok && outputs.conn2.ok && outputs.nver.ok
+  uses: shell
+  with:
+    cmd: "cat {{ outputs.container.log }}"
+  echo: "{{ res.stdout }}"

--- a/testdata/jobs/container-multiport.yml
+++ b/testdata/jobs/container-multiport.yml
@@ -136,7 +136,7 @@ steps:
   id: noerr
   uses: shell
   with:
-    cmd: "grep -i error {{ outputs.container.log }}"
+    cmd: "grep 'level=ERROR' {{ outputs.container.log }}"
   test: status == 1
   outputs:
     ok: status == 1
@@ -148,9 +148,9 @@ steps:
     cmd: |
       grep 'Starting new container' {{ outputs.container.log }} | \
         grep -c {{ vars.new_version }} | tr -d '\n'
-  test: res.stdout == "{{ vars.replicas }}"
+  test: int(res.stdout) == int(vars.replicas)
   outputs:
-    ok: res.stdout == "{{ vars.replicas }}"
+    ok: int(res.stdout) == int(vars.replicas)
 
 - name: Show log
   skipif: outputs.noerr.ok && outputs.proxy1.ok && outputs.proxy2.ok && outputs.allproxies.ok && outputs.backend1.ok && outputs.backend2.ok && outputs.conn1.ok && outputs.conn2.ok && outputs.nver.ok

--- a/testdata/jobs/container-multiport.yml
+++ b/testdata/jobs/container-multiport.yml
@@ -27,6 +27,7 @@ steps:
 
 - name: Wait for new version to start
   uses: shell
+  timeout: 10m
   retry:
     max_attempts: 120
     interval: 5s

--- a/testdata/jobs/container-multiport.yml
+++ b/testdata/jobs/container-multiport.yml
@@ -5,7 +5,7 @@ steps:
   id: container
   uses: shell
   with:
-    workdir: ./testdata/container/{{ vars.registry }}
+    workdir: ./testdata/container-multiport/{{ vars.registry }}
     background: true
     env:
       GITHUB_TOKEN: "{{ vars.github_token }}"
@@ -27,7 +27,6 @@ steps:
 
 - name: Wait for new version to start
   uses: shell
-  timeout: 10m
   retry:
     max_attempts: 120
     interval: 5s

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -53,7 +53,7 @@ steps:
   id: noerr
   uses: shell
   with:
-    cmd: "grep -i error {{ outputs.container.log }}"
+    cmd: "grep 'level=ERROR' {{ outputs.container.log }}"
   test: status == 1
   outputs:
     ok: status == 1

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -24,6 +24,7 @@ steps:
 
 - name: Wait for new version to start
   uses: shell
+  timeout: 10m
   retry:
     max_attempts: 120
     interval: 5s

--- a/testdata/jobs/container.yml
+++ b/testdata/jobs/container.yml
@@ -24,7 +24,6 @@ steps:
 
 - name: Wait for new version to start
   uses: shell
-  timeout: 10m
   retry:
     max_attempts: 120
     interval: 5s


### PR DESCRIPTION
## Summary

- Replace HTTP reverse proxy with TCP (L4) proxy to support multiple protocols
- Enable multiple port mappings for container command (e.g., `--port 80:80 --port 9090:9090`)
- Add comprehensive unit tests and E2E integration tests

## Changes

### TCP Proxy Implementation
- Replace `httputil.ReverseProxy` with TCP-level proxy using `io.Copy` for bidirectional streaming
- Support multiple protocols: HTTP/1.1, HTTP/2, gRPC, WebSocket, and any TCP-based protocol
- Each port mapping gets its own TCP listener with independent backend pool
- Round-robin load balancing across container replicas

### Usage
```bash
# Single port (existing behavior)
dewy container --port 8080:80 --registry docker://...

# Multiple ports (new feature)
dewy container --port 80:80 --port 9090:9090 --registry docker://...
```

### Testing
- Unit tests for `tcpProxy` struct and methods
- Unit tests for multi-port proxy management in `Dewy`
- E2E test with two proxy ports mapping to the same container port

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] E2E tests pass in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)