### PR TITLE
feat: add blue/green deployment support via build metadata slots

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -51,6 +51,7 @@ type cli struct {
 	ContainerRuntime string   `long:"runtime" description:"Container runtime (docker or podman, default: docker)"`
 	Cmd              []string `long:"cmd" description:"Command and arguments to pass to container (can be specified multiple times)"`
 	AdminPort        int      `long:"admin-port" description:"Admin API port for container command (default: 17539, auto-increments if in use)"`
+	Slot             string   `long:"slot" short:"s" description:"Deployment slot for blue/green deployment (e.g., blue, green). Only deploys if tag's build metadata matches."`
 	Help             bool     `long:"help" short:"h" description:"show this help message and exit"`
 	Version          bool     `long:"version" short:"v" description:"prints the version number"`
 }
@@ -137,6 +138,7 @@ func (c *cli) showHelp() {
 	generalOpts := strings.Join(c.buildHelp([]string{
 		"Interval",
 		"Registry",
+		"Slot",
 		"Notifier",
 		"LogLevel",
 		"LogFormat",
@@ -257,6 +259,7 @@ func (c *cli) run() int {
 	conf.BeforeDeployHook = c.BeforeDeployHook
 	conf.AfterDeployHook = c.AfterDeployHook
 	conf.AdminPort = c.AdminPort
+	conf.Slot = c.Slot
 
 	switch c.command {
 	case "server":

--- a/config.go
+++ b/config.go
@@ -91,6 +91,7 @@ type Config struct {
 	Container        *ContainerConfig
 	BeforeDeployHook string
 	AfterDeployHook  string
+	Slot             string // Deployment slot for blue/green deployment (e.g., "blue", "green")
 	*Info
 }
 

--- a/dewy.go
+++ b/dewy.go
@@ -250,6 +250,15 @@ func (d *Dewy) Run() error {
 		return err
 	}
 
+	// Check slot matching for blue/green deployment
+	if d.config.Slot != "" && res.Slot != d.config.Slot {
+		d.logger.Debug("Deploy skipped: slot mismatch",
+			slog.String("expected_slot", d.config.Slot),
+			slog.String("actual_slot", res.Slot),
+			slog.String("tag", res.Tag))
+		return nil
+	}
+
 	// Check cache
 	cachekeyName := d.cachekeyName(res)
 	currentkeyValue, _ := d.cache.Read(currentkeyName)
@@ -641,7 +650,17 @@ func (d *Dewy) RunContainer() error {
 	d.logger.Debug("Found latest image",
 		slog.String("tag", res.Tag),
 		slog.String("digest", res.ID),
-		slog.String("url", res.ArtifactURL))
+		slog.String("url", res.ArtifactURL),
+		slog.String("slot", res.Slot))
+
+	// Check slot matching for blue/green deployment
+	if d.config.Slot != "" && res.Slot != d.config.Slot {
+		d.logger.Debug("Deploy skipped: slot mismatch",
+			slog.String("expected_slot", d.config.Slot),
+			slog.String("actual_slot", res.Slot),
+			slog.String("tag", res.Tag))
+		return nil
+	}
 
 	// Extract image reference from artifact URL
 	imageRef := strings.TrimPrefix(res.ArtifactURL, "img://")

--- a/registry/ghr.go
+++ b/registry/ghr.go
@@ -156,11 +156,18 @@ func (g *GHR) Current(ctx context.Context) (*CurrentResponse, error) {
 
 	au := fmt.Sprintf("%s://%s/%s/tag/%s/%s", ghrScheme, g.Owner, g.Repo, release.GetTagName(), artifactName)
 
+	// Extract slot from build metadata
+	var slot string
+	if sv := ParseSemVer(release.GetTagName()); sv != nil {
+		slot = sv.BuildMetadata
+	}
+
 	return &CurrentResponse{
 		ID:          time.Now().Format(ISO8601),
 		Tag:         release.GetTagName(),
 		ArtifactURL: au,
 		CreatedAt:   release.PublishedAt.GetTime(),
+		Slot:        slot,
 	}, nil
 }
 

--- a/registry/grpc.go
+++ b/registry/grpc.go
@@ -73,11 +73,18 @@ func (c *GRPC) Current(ctx context.Context) (*CurrentResponse, error) {
 		createdAt = &t
 	}
 
+	// Extract slot from build metadata
+	var slot string
+	if sv := ParseSemVer(cres.Tag); sv != nil {
+		slot = sv.BuildMetadata
+	}
+
 	res := &CurrentResponse{
 		ID:          cres.Id,
 		Tag:         cres.Tag,
 		ArtifactURL: cres.ArtifactUrl,
 		CreatedAt:   createdAt,
+		Slot:        slot,
 	}
 	return res, nil
 }

--- a/registry/gs.go
+++ b/registry/gs.go
@@ -140,6 +140,7 @@ func (g *GS) Current(ctx context.Context) (*CurrentResponse, error) {
 		Tag:         version.String(),
 		ArtifactURL: g.buildArtifactURL(prefix + artifactName),
 		CreatedAt:   createdAt,
+		Slot:        version.BuildMetadata,
 	}, nil
 }
 

--- a/registry/oci.go
+++ b/registry/oci.go
@@ -103,11 +103,18 @@ func (o *OCI) Current(ctx context.Context) (*CurrentResponse, error) {
 
 	imageRef := fmt.Sprintf("%s/%s:%s", o.Registry, o.Repository, latestTag)
 
+	// Extract slot from build metadata
+	var slot string
+	if sv := ParseSemVer(latestTag); sv != nil {
+		slot = sv.BuildMetadata
+	}
+
 	return &CurrentResponse{
 		ID:          digest,
 		Tag:         latestTag,
 		ArtifactURL: fmt.Sprintf("img://%s", imageRef),
 		CreatedAt:   createdAt,
+		Slot:        slot,
 	}, nil
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -37,6 +37,9 @@ type CurrentResponse struct {
 	ArtifactURL string
 	// CreatedAt is the creation time of the release
 	CreatedAt *time.Time
+	// Slot is the deployment slot extracted from build metadata (e.g., "blue", "green").
+	// This is used for blue/green deployment support.
+	Slot string
 }
 
 // ReportRequest is the request to report the result of deploying the artifact.

--- a/registry/s3.go
+++ b/registry/s3.go
@@ -160,6 +160,7 @@ func (s *S3) Current(ctx context.Context) (*CurrentResponse, error) {
 		Tag:         version.String(),
 		ArtifactURL: s.buildArtifactURL(prefix + artifactName),
 		CreatedAt:   createdAt,
+		Slot:        version.BuildMetadata,
 	}, nil
 }
 

--- a/registry/semver_test.go
+++ b/registry/semver_test.go
@@ -17,6 +17,10 @@ func TestSemVerRegexWithoutPreRelease(t *testing.T) {
 		{"v8", false},
 		{"12.3", false},
 		{"abcdefg-10", false},
+		// Build metadata tests
+		{"v1.2.3+blue", true},
+		{"v1.2.3+green", true},
+		{"v1.2.3+build.123", true},
 	}
 
 	for _, tt := range tests {
@@ -42,6 +46,12 @@ func TestSemVerRegex(t *testing.T) {
 		{"v8", false},
 		{"12.3", false},
 		{"abcdefg-10", false},
+		// Build metadata tests
+		{"v1.2.3+blue", true},
+		{"v1.2.3+green", true},
+		{"v1.2.3+build.123", true},
+		{"v1.2.3-rc.1+blue", true},
+		{"v1.2.3-beta+green", true},
 	}
 
 	for _, tt := range tests {
@@ -49,6 +59,155 @@ func TestSemVerRegex(t *testing.T) {
 			got := SemVerRegex.MatchString(tt.ver)
 			if got != tt.expected {
 				t.Errorf("expected %t, got %t", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseSemVerBuildMetadata(t *testing.T) {
+	tests := []struct {
+		ver           string
+		expectedBuild string
+		expectedPre   string
+	}{
+		{"v1.2.3", "", ""},
+		{"v1.2.3+blue", "blue", ""},
+		{"v1.2.3+green", "green", ""},
+		{"v1.2.3-rc.1", "", "rc.1"},
+		{"v1.2.3-rc.1+blue", "blue", "rc.1"},
+		{"v1.2.3-beta+green", "green", "beta"},
+		{"v1.2.3+build.123", "build.123", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ver, func(t *testing.T) {
+			sv := ParseSemVer(tt.ver)
+			if sv == nil {
+				t.Fatalf("ParseSemVer(%s) returned nil", tt.ver)
+			}
+			if sv.BuildMetadata != tt.expectedBuild {
+				t.Errorf("BuildMetadata = %q, want %q", sv.BuildMetadata, tt.expectedBuild)
+			}
+			if sv.PreRelease != tt.expectedPre {
+				t.Errorf("PreRelease = %q, want %q", sv.PreRelease, tt.expectedPre)
+			}
+		})
+	}
+}
+
+func TestSemVerString(t *testing.T) {
+	tests := []struct {
+		ver      string
+		expected string
+	}{
+		{"v1.2.3", "v1.2.3"},
+		{"v1.2.3+blue", "v1.2.3+blue"},
+		{"v1.2.3-rc.1", "v1.2.3-rc.1"},
+		{"v1.2.3-rc.1+blue", "v1.2.3-rc.1+blue"},
+		{"1.2.3+green", "1.2.3+green"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ver, func(t *testing.T) {
+			sv := ParseSemVer(tt.ver)
+			if sv == nil {
+				t.Fatalf("ParseSemVer(%s) returned nil", tt.ver)
+			}
+			if sv.String() != tt.expected {
+				t.Errorf("String() = %q, want %q", sv.String(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindLatestSemVerWithSlot(t *testing.T) {
+	tests := []struct {
+		name            string
+		versionNames    []string
+		slot            string
+		allowPreRelease bool
+		expectedVer     string
+		expectedName    string
+		expectError     bool
+	}{
+		{
+			name:            "find latest with slot blue",
+			versionNames:    []string{"v1.0.0+blue", "v1.1.0+green", "v1.2.0+blue", "v1.3.0+green"},
+			slot:            "blue",
+			allowPreRelease: false,
+			expectedVer:     "v1.2.0+blue",
+			expectedName:    "v1.2.0+blue",
+			expectError:     false,
+		},
+		{
+			name:            "find latest with slot green",
+			versionNames:    []string{"v1.0.0+blue", "v1.1.0+green", "v1.2.0+blue", "v1.3.0+green"},
+			slot:            "green",
+			allowPreRelease: false,
+			expectedVer:     "v1.3.0+green",
+			expectedName:    "v1.3.0+green",
+			expectError:     false,
+		},
+		{
+			name:            "find latest without slot (any)",
+			versionNames:    []string{"v1.0.0+blue", "v1.1.0+green", "v1.2.0+blue", "v1.3.0+green"},
+			slot:            "",
+			allowPreRelease: false,
+			expectedVer:     "v1.3.0+green",
+			expectedName:    "v1.3.0+green",
+			expectError:     false,
+		},
+		{
+			name:            "find latest with slot and pre-release",
+			versionNames:    []string{"v1.0.0+blue", "v1.1.0-rc.1+blue", "v1.0.5+blue"},
+			slot:            "blue",
+			allowPreRelease: true,
+			expectedVer:     "v1.1.0-rc.1+blue",
+			expectedName:    "v1.1.0-rc.1+blue",
+			expectError:     false,
+		},
+		{
+			name:            "no matching slot",
+			versionNames:    []string{"v1.0.0+blue", "v1.1.0+blue"},
+			slot:            "green",
+			allowPreRelease: false,
+			expectedVer:     "",
+			expectedName:    "",
+			expectError:     true,
+		},
+		{
+			name:            "mixed with and without build metadata",
+			versionNames:    []string{"v1.0.0", "v1.1.0+blue", "v1.2.0", "v1.3.0+blue"},
+			slot:            "blue",
+			allowPreRelease: false,
+			expectedVer:     "v1.3.0+blue",
+			expectedName:    "v1.3.0+blue",
+			expectError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVer, gotName, err := FindLatestSemVerWithSlot(tt.versionNames, tt.slot, tt.allowPreRelease)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("FindLatestSemVerWithSlot() expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("FindLatestSemVerWithSlot() unexpected error: %v", err)
+				return
+			}
+
+			if gotVer.String() != tt.expectedVer {
+				t.Errorf("FindLatestSemVerWithSlot() version = %v, want %v", gotVer.String(), tt.expectedVer)
+			}
+
+			if gotName != tt.expectedName {
+				t.Errorf("FindLatestSemVerWithSlot() name = %v, want %v", gotName, tt.expectedName)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add support for blue/green deployment patterns using semver build metadata
- Users can tag releases with deployment slots (e.g., `v1.2.3+blue`, `v1.2.3+green`)
- Dewy instances can be configured with `--slot` to only deploy matching versions

## Changes

- Extend semver parser to support build metadata (`+xxx`)
- Add `Slot` field to `CurrentResponse` for all registry implementations (ghr, oci, s3, gs, grpc)
- Add `--slot` CLI option for server and container commands
- Add slot matching logic in `Run()` and `RunContainer()`
- Add comprehensive tests for build metadata parsing and slot filtering
- Update documentation (README, docs/pages/versioning) with blue/green deployment examples

## Usage

```bash
# Tag releases with build metadata
gh release create v1.2.3+blue ...
gh release create v1.2.3+green ...

# Start Dewy with slot filtering
dewy server --registry ghr://owner/repo --slot blue -- ./myapp
dewy server --registry ghr://owner/repo --slot green -- ./myapp
```

## Test plan

- [x] All existing tests pass
- [x] New semver tests for build metadata parsing
- [x] New tests for `FindLatestSemVerWithSlot()`
- [x] Manual verification of `--slot` option in help output

🤖 Generated with [Claude Code](https://claude.ai/code)