### PR TITLE
fix: add pagination support for OCI registry tags list

### DIFF
--- a/registry/oci_test.go
+++ b/registry/oci_test.go
@@ -542,6 +542,21 @@ func TestOCI_parseNextLink(t *testing.T) {
 			linkHeader: `</v2/testapp/tags/list?n=100&last=v1.0.0>`,
 			expected:   "",
 		},
+		{
+			name:       "multiple links with next and prev",
+			linkHeader: `</v2/testapp/tags/list?n=100&last=v0.9.0>; rel="prev", </v2/testapp/tags/list?n=100&last=v2.0.0>; rel="next"`,
+			expected:   "https://ghcr.io/v2/testapp/tags/list?n=100&last=v2.0.0",
+		},
+		{
+			name:       "multiple links with next first",
+			linkHeader: `</v2/testapp/tags/list?n=100&last=v3.0.0>; rel="next", </v2/testapp/tags/list?n=100&last=v1.0.0>; rel="prev"`,
+			expected:   "https://ghcr.io/v2/testapp/tags/list?n=100&last=v3.0.0",
+		},
+		{
+			name:       "multiple links without next",
+			linkHeader: `</v2/testapp/tags/list?n=100&last=v0.9.0>; rel="prev", </v2/testapp/tags/list?n=100&last=v0.1.0>; rel="first"`,
+			expected:   "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fix OCI registry tags/list API returning only 100 tags by default
- Add pagination support by parsing Link header
- Comply with OCI Distribution Spec 1.1

## Problem
When OCI registries like ghcr.io have more than 100 tags, newer tags were not visible, causing Container e2e tests to fail.

## Solution
- Add pagination to `listTags` function
- Create `fetchTagsPage` function to fetch a single page of tags
- Create `parseNextLink` function to extract next page URL from Link header
- Maintain backward compatibility when Link header is not present

## Test plan
- [x] Existing unit tests pass
- [ ] e2e Container tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)