### PR TITLE
feat: add automatic registry authentication for container pull

### DIFF
--- a/container/docker.go
+++ b/container/docker.go
@@ -16,9 +16,10 @@ import (
 
 // Docker implements Runtime interface using Docker CLI.
 type Docker struct {
-	cmd       string
-	logger    *slog.Logger
-	drainTime time.Duration
+	cmd                string
+	logger             *slog.Logger
+	drainTime          time.Duration
+	loggedInRegistries map[string]bool // Track registries we've logged into
 }
 
 // Forbidden options that conflict with Dewy management
@@ -39,10 +40,119 @@ func NewDocker(logger *slog.Logger, drainTime time.Duration) (*Docker, error) {
 	}
 
 	return &Docker{
-		cmd:       cmd,
-		logger:    logger,
-		drainTime: drainTime,
+		cmd:                cmd,
+		logger:             logger,
+		drainTime:          drainTime,
+		loggedInRegistries: make(map[string]bool),
 	}, nil
+}
+
+// extractRegistry extracts the registry host from an image reference.
+// For images without explicit registry (e.g., "nginx:latest"), returns "docker.io".
+// For images with registry (e.g., "ghcr.io/owner/repo:tag"), returns the registry host.
+func extractRegistry(imageRef string) string {
+	// Remove tag or digest
+	ref := imageRef
+	if idx := strings.LastIndex(ref, "@"); idx != -1 {
+		ref = ref[:idx]
+	}
+	if idx := strings.LastIndex(ref, ":"); idx != -1 {
+		// Check if this is a port number (e.g., localhost:5000/image)
+		slashIdx := strings.LastIndex(ref[:idx], "/")
+		if slashIdx == -1 || !strings.Contains(ref[slashIdx:idx], ".") {
+			ref = ref[:idx]
+		}
+	}
+
+	// Check if the first part contains a dot or colon (indicating a registry)
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 1 {
+		// No slash, it's a Docker Hub official image (e.g., "nginx")
+		return "docker.io"
+	}
+
+	firstPart := parts[0]
+	if strings.Contains(firstPart, ".") || strings.Contains(firstPart, ":") || firstPart == "localhost" {
+		return firstPart
+	}
+
+	// No registry specified (e.g., "library/nginx"), use Docker Hub
+	return "docker.io"
+}
+
+// getCredentials returns username and password for the given registry from environment variables.
+func getCredentials(registry string) (username, password string) {
+	// GitHub Container Registry
+	if strings.Contains(registry, "ghcr.io") {
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+			return "token", token
+		}
+	}
+
+	// AWS ECR - check for ECR-specific credentials first
+	if strings.Contains(registry, ".ecr.") && strings.Contains(registry, ".amazonaws.com") {
+		if token := os.Getenv("AWS_ECR_PASSWORD"); token != "" {
+			return "AWS", token
+		}
+	}
+
+	// Google Artifact Registry / Container Registry
+	if strings.Contains(registry, "gcr.io") || strings.Contains(registry, "-docker.pkg.dev") {
+		if token := os.Getenv("GCR_TOKEN"); token != "" {
+			return "_json_key", token
+		}
+	}
+
+	// Generic credentials (fallback)
+	username = os.Getenv("DOCKER_USERNAME")
+	password = os.Getenv("DOCKER_PASSWORD")
+
+	return username, password
+}
+
+// isAuthError checks if the error message indicates an authentication failure.
+func isAuthError(output string) bool {
+	lowerOutput := strings.ToLower(output)
+	authIndicators := []string{
+		"unauthorized",
+		"authentication required",
+		"denied",
+		"access forbidden",
+		"not authorized",
+		"login required",
+	}
+	for _, indicator := range authIndicators {
+		if strings.Contains(lowerOutput, indicator) {
+			return true
+		}
+	}
+	return false
+}
+
+// Login authenticates with the specified registry using credentials from environment variables.
+func (d *Docker) Login(ctx context.Context, registry string) error {
+	username, password := getCredentials(registry)
+	if username == "" || password == "" {
+		d.logger.Debug("No credentials found for registry", slog.String("registry", registry))
+		return nil
+	}
+
+	d.logger.Info("Logging in to registry", slog.String("registry", registry))
+
+	// Use --password-stdin for security
+	// #nosec G204 - args are constructed internally from validated inputs
+	cmd := exec.CommandContext(ctx, d.cmd, "login", "-u", username, "--password-stdin", registry)
+	cmd.Stdin = strings.NewReader(password)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker login failed for %s: %w: %s", registry, err, string(output))
+	}
+
+	d.loggedInRegistries[registry] = true
+	d.logger.Info("Successfully logged in to registry", slog.String("registry", registry))
+
+	return nil
 }
 
 // validateExtraArgs checks if any forbidden options are present in extra args.
@@ -146,22 +256,51 @@ func (d *Docker) execCommandOutput(ctx context.Context, args ...string) (string,
 
 // Pull pulls an image from the registry.
 // If the image already exists locally, it will still attempt to pull to get the latest version.
+// Automatically handles authentication: logs in on first pull and retries on auth errors.
 func (d *Docker) Pull(ctx context.Context, imageRef string) error {
 	// Check if image exists locally first
-	_, err := d.execCommandOutput(ctx, "image", "inspect", imageRef)
-	if err == nil {
+	_, localErr := d.execCommandOutput(ctx, "image", "inspect", imageRef)
+	if localErr == nil {
 		// Image exists locally
 		d.logger.Info("Image already exists locally, pulling to check for updates",
 			slog.String("image", imageRef))
 	}
 
+	// Extract registry and attempt login if not already logged in
+	registry := extractRegistry(imageRef)
+	if !d.loggedInRegistries[registry] {
+		if err := d.Login(ctx, registry); err != nil {
+			d.logger.Warn("Initial login failed, will attempt pull anyway",
+				slog.String("registry", registry),
+				slog.String("error", err.Error()))
+		}
+	}
+
 	// Always try to pull to get the latest version
 	// For local-only images (not in a registry), this will fail but that's expected
 	d.logger.Info("Pulling image", slog.String("image", imageRef))
-	pullErr := d.execCommand(ctx, "pull", imageRef)
+	output, pullErr := d.pullImage(ctx, imageRef)
+
+	// If pull fails with auth error, retry login and pull again
+	if pullErr != nil && isAuthError(output) {
+		d.logger.Info("Authentication error detected, attempting re-login",
+			slog.String("registry", registry))
+
+		// Clear the logged-in status and retry login
+		delete(d.loggedInRegistries, registry)
+		if loginErr := d.Login(ctx, registry); loginErr != nil {
+			d.logger.Error("Re-login failed",
+				slog.String("registry", registry),
+				slog.String("error", loginErr.Error()))
+		} else {
+			// Retry pull after successful re-login
+			d.logger.Info("Retrying pull after re-login", slog.String("image", imageRef))
+			output, pullErr = d.pullImage(ctx, imageRef)
+		}
+	}
 
 	// If pull fails but image exists locally, we can use the local image
-	if pullErr != nil && err == nil {
+	if pullErr != nil && localErr == nil {
 		d.logger.Warn("Failed to pull image, but local image exists - using local version",
 			slog.String("image", imageRef),
 			slog.String("pull_error", pullErr.Error()))
@@ -169,6 +308,26 @@ func (d *Docker) Pull(ctx context.Context, imageRef string) error {
 	}
 
 	return pullErr
+}
+
+// pullImage executes docker pull and returns output and error.
+func (d *Docker) pullImage(ctx context.Context, imageRef string) (string, error) {
+	// #nosec G204 - args are constructed internally from validated inputs
+	cmd := exec.CommandContext(ctx, d.cmd, "pull", imageRef)
+	d.logger.Debug("Executing docker command",
+		slog.String("cmd", d.cmd),
+		slog.Any("args", []string{"pull", imageRef}))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		d.logger.Error("Docker pull failed",
+			slog.String("image", imageRef),
+			slog.String("output", string(output)),
+			slog.String("error", err.Error()))
+		return string(output), fmt.Errorf("docker pull %s failed: %w: %s", imageRef, err, string(output))
+	}
+
+	return string(output), nil
 }
 
 // Run starts a new container and returns the container ID.

--- a/container/docker.go
+++ b/container/docker.go
@@ -295,7 +295,7 @@ func (d *Docker) Pull(ctx context.Context, imageRef string) error {
 		} else {
 			// Retry pull after successful re-login
 			d.logger.Info("Retrying pull after re-login", slog.String("image", imageRef))
-			output, pullErr = d.pullImage(ctx, imageRef)
+			_, pullErr = d.pullImage(ctx, imageRef)
 		}
 	}
 

--- a/container/podman.go
+++ b/container/podman.go
@@ -152,7 +152,7 @@ func (p *Podman) Pull(ctx context.Context, imageRef string) error {
 		} else {
 			// Retry pull after successful re-login
 			p.logger.Info("Retrying pull after re-login", slog.String("image", imageRef))
-			output, pullErr = p.pullImage(ctx, imageRef)
+			_, pullErr = p.pullImage(ctx, imageRef)
 		}
 	}
 

--- a/container/podman.go
+++ b/container/podman.go
@@ -16,9 +16,10 @@ import (
 
 // Podman implements Runtime interface using Podman CLI.
 type Podman struct {
-	cmd       string
-	logger    *slog.Logger
-	drainTime time.Duration
+	cmd                string
+	logger             *slog.Logger
+	drainTime          time.Duration
+	loggedInRegistries map[string]bool // Track registries we've logged into
 }
 
 // NewPodman creates a new Podman runtime.
@@ -29,10 +30,37 @@ func NewPodman(logger *slog.Logger, drainTime time.Duration) (*Podman, error) {
 	}
 
 	return &Podman{
-		cmd:       cmd,
-		logger:    logger,
-		drainTime: drainTime,
+		cmd:                cmd,
+		logger:             logger,
+		drainTime:          drainTime,
+		loggedInRegistries: make(map[string]bool),
 	}, nil
+}
+
+// Login authenticates with the specified registry using credentials from environment variables.
+func (p *Podman) Login(ctx context.Context, registry string) error {
+	username, password := getCredentials(registry)
+	if username == "" || password == "" {
+		p.logger.Debug("No credentials found for registry", slog.String("registry", registry))
+		return nil
+	}
+
+	p.logger.Info("Logging in to registry", slog.String("registry", registry))
+
+	// Use --password-stdin for security
+	// #nosec G204 - args are constructed internally from validated inputs
+	cmd := exec.CommandContext(ctx, p.cmd, "login", "-u", username, "--password-stdin", registry)
+	cmd.Stdin = strings.NewReader(password)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("podman login failed for %s: %w: %s", registry, err, string(output))
+	}
+
+	p.loggedInRegistries[registry] = true
+	p.logger.Info("Successfully logged in to registry", slog.String("registry", registry))
+
+	return nil
 }
 
 // execCommand executes a podman command without returning output.
@@ -85,22 +113,51 @@ func (p *Podman) execCommandOutput(ctx context.Context, args ...string) (string,
 
 // Pull pulls an image from the registry.
 // If the image already exists locally, it will still attempt to pull to get the latest version.
+// Automatically handles authentication: logs in on first pull and retries on auth errors.
 func (p *Podman) Pull(ctx context.Context, imageRef string) error {
 	// Check if image exists locally first
-	_, err := p.execCommandOutput(ctx, "image", "inspect", imageRef)
-	if err == nil {
+	_, localErr := p.execCommandOutput(ctx, "image", "inspect", imageRef)
+	if localErr == nil {
 		// Image exists locally
 		p.logger.Info("Image already exists locally, pulling to check for updates",
 			slog.String("image", imageRef))
 	}
 
+	// Extract registry and attempt login if not already logged in
+	registry := extractRegistry(imageRef)
+	if !p.loggedInRegistries[registry] {
+		if err := p.Login(ctx, registry); err != nil {
+			p.logger.Warn("Initial login failed, will attempt pull anyway",
+				slog.String("registry", registry),
+				slog.String("error", err.Error()))
+		}
+	}
+
 	// Always try to pull to get the latest version
 	// For local-only images (not in a registry), this will fail but that's expected
 	p.logger.Info("Pulling image", slog.String("image", imageRef))
-	pullErr := p.execCommand(ctx, "pull", imageRef)
+	output, pullErr := p.pullImage(ctx, imageRef)
+
+	// If pull fails with auth error, retry login and pull again
+	if pullErr != nil && isAuthError(output) {
+		p.logger.Info("Authentication error detected, attempting re-login",
+			slog.String("registry", registry))
+
+		// Clear the logged-in status and retry login
+		delete(p.loggedInRegistries, registry)
+		if loginErr := p.Login(ctx, registry); loginErr != nil {
+			p.logger.Error("Re-login failed",
+				slog.String("registry", registry),
+				slog.String("error", loginErr.Error()))
+		} else {
+			// Retry pull after successful re-login
+			p.logger.Info("Retrying pull after re-login", slog.String("image", imageRef))
+			output, pullErr = p.pullImage(ctx, imageRef)
+		}
+	}
 
 	// If pull fails but image exists locally, we can use the local image
-	if pullErr != nil && err == nil {
+	if pullErr != nil && localErr == nil {
 		p.logger.Warn("Failed to pull image, but local image exists - using local version",
 			slog.String("image", imageRef),
 			slog.String("pull_error", pullErr.Error()))
@@ -108,6 +165,26 @@ func (p *Podman) Pull(ctx context.Context, imageRef string) error {
 	}
 
 	return pullErr
+}
+
+// pullImage executes podman pull and returns output and error.
+func (p *Podman) pullImage(ctx context.Context, imageRef string) (string, error) {
+	// #nosec G204 - args are constructed internally from validated inputs
+	cmd := exec.CommandContext(ctx, p.cmd, "pull", imageRef)
+	p.logger.Debug("Executing podman command",
+		slog.String("cmd", p.cmd),
+		slog.Any("args", []string{"pull", imageRef}))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		p.logger.Error("Podman pull failed",
+			slog.String("image", imageRef),
+			slog.String("output", string(output)),
+			slog.String("error", err.Error()))
+		return string(output), fmt.Errorf("podman pull %s failed: %w: %s", imageRef, err, string(output))
+	}
+
+	return string(output), nil
 }
 
 // Run starts a new container and returns the container ID.


### PR DESCRIPTION
## Summary

- Add automatic `docker login` / `podman login` when pulling images from private registries
- Eliminate the need for users to run `docker login` beforehand
- Handle token expiration by retrying login on authentication errors

## Changes

### New Functions
- `extractRegistry(imageRef)` - Extract registry host from image reference
- `getCredentials(registry)` - Get credentials from environment variables based on registry
- `isAuthError(output)` - Detect authentication errors in command output
- `Login(ctx, registry)` - Execute `docker/podman login --password-stdin`

### Modified Functions
- `Pull()` - Now auto-logs in on first pull and retries on auth errors

## Supported Registries

| Registry | Environment Variables |
|----------|----------------------|
| GitHub Container Registry (ghcr.io) | `GITHUB_TOKEN` |
| AWS ECR | `AWS_ECR_PASSWORD` |
| Google Container/Artifact Registry | `GCR_TOKEN` |
| Generic registries | `DOCKER_USERNAME` / `DOCKER_PASSWORD` |

## Authentication Flow

```
Pull("ghcr.io/owner/repo:v1")
  ↓
extractRegistry → "ghcr.io"
  ↓
Already logged in? → No → Login(ghcr.io)
  ↓
docker pull ghcr.io/owner/repo:v1
  ↓
Auth error? → Yes → Re-login → Retry pull
```

## Test plan

- [x] Unit tests for `extractRegistry()` - various image reference formats
- [x] Unit tests for `getCredentials()` - all supported registries
- [x] Unit tests for `isAuthError()` - various error messages
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)