### PR TITLE
fix: checkout PR head commit instead of main branch in e2e test

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -37,7 +37,7 @@ jobs:
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR'))
     steps:
-    - name: Get PR ref for comment trigger
+    - name: Get PR info for comment trigger
       if: github.event_name == 'issue_comment'
       id: pr
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -48,7 +48,7 @@ jobs:
             repo: context.repo.repo,
             pull_number: context.issue.number
           });
-          core.setOutput('ref', pr.head.ref);
+          core.setOutput('ref', `refs/pull/${context.issue.number}/head`);
           core.setOutput('sha', pr.head.sha);
 
     - name: Add reaction to comment
@@ -65,7 +65,7 @@ jobs:
 
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
-        ref: ${{ steps.pr.outputs.ref || github.ref }}
+        ref: ${{ steps.pr.outputs.sha || github.sha }}
 
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:


### PR DESCRIPTION
## Summary
- Fix e2e tests triggered by PR comments (`/run-e2e`) running against main branch code instead of the PR branch code
- The `issue_comment` event always sets `github.sha` to the default branch's latest commit, so checkout was using main branch code
- Use the PR head commit SHA from the GitHub API for checkout, which reliably resolves to the exact PR commit regardless of whether the PR is from a fork or the same repository
- `push` and `workflow_dispatch` events fall back to `github.sha` as before, so existing behavior is unaffected

## Test plan
- [ ] Trigger `/run-e2e` on a PR and verify the e2e test runs against the PR branch code
- [ ] Verify e2e tests on push to main continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)