### PR TITLE
docs: add chat:write.customize to required Slack OAuth scopes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -296,7 +296,7 @@ $ dewy --notifier "slack://general?title=myapp&quiet=true" ...
 
 Slackを通知に使う場合は以下の設定をします。オプションには、通知に付加する `title` と そのリンクである `url` が設定できます。リポジトリ名やそのURLを設定すると良いでしょう。
 また、Slack APIを利用するために必要な環境変数の設定が必要です。
-[Slack Appを作成](https://api.slack.com/apps)し、 OAuth Tokenを発行して設定してください。OAuthのScopeは `chat:write` が必要です。また、通知先のチャンネルには事前にSlack Appをinviteしておく必要があります。
+[Slack Appを作成](https://api.slack.com/apps)し、 OAuth Tokenを発行して設定してください。OAuthのScopeは `chat:write` と `chat:write.customize` が必要です。また、通知先のチャンネルには事前にSlack Appをinviteしておく必要があります。
 
 ```sh
 # 構造

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ $ dewy --notifier "slack://general?title=myapp&quiet=true" ...
 
 ### Slack
 
-To use Slack for notifications, configure as follows. Options include a title and url that can link to the repository name or URL. You'll need to [create a Slack App](https://api.slack.com/apps), generate an OAuth Token, and set the required environment variables. The app requires the `chat:write` permission. You must also invite the Slack App to the notification channel in advance.
+To use Slack for notifications, configure as follows. Options include a title and url that can link to the repository name or URL. You'll need to [create a Slack App](https://api.slack.com/apps), generate an OAuth Token, and set the required environment variables. The app requires the `chat:write` and `chat:write.customize` permissions. You must also invite the Slack App to the notification channel in advance.
 
 ```sh
 # Format

--- a/docs/pages/ja/notifier.md
+++ b/docs/pages/ja/notifier.md
@@ -63,6 +63,7 @@ export SLACK_TOKEN=xoxb-xxxxxxxxxxxxxxxxxxxxx
    - [https://api.slack.com/apps](https://api.slack.com/apps) でアプリを作成
 2. 必要な権限（Scopes）
    - `chat:write`: メッセージの投稿
+   - `chat:write.customize`: メッセージごとのBot名とアイコンのカスタマイズ
 3. 通知先チャンネルへのSlack Appの招待
    - 通知を送信する前に、Slack GUIからアプリをチャンネルにinviteしておく必要があります
 4. トークンの取得
@@ -274,7 +275,7 @@ Slack通知が届かない
      https://slack.com/api/auth.test
    ```
 2. **権限の確認**
-   - Bot Token Scopesで `chat:write` が設定されているか
+   - Bot Token Scopesで `chat:write` と `chat:write.customize` が設定されているか
    - Appがワークスペースにインストールされているか
 3. **チャンネル名の確認**
    ```bash

--- a/docs/pages/notifier.md
+++ b/docs/pages/notifier.md
@@ -63,6 +63,7 @@ export SLACK_TOKEN=xoxb-xxxxxxxxxxxxxxxxxxxxx
    - Create app at [https://api.slack.com/apps](https://api.slack.com/apps)
 2. Required permissions (Scopes)
    - `chat:write`: Post messages
+   - `chat:write.customize`: Customize bot name and icon per message
 3. Invite the Slack App to the notification channel
    - You must invite the app to the channel via Slack GUI before sending notifications
 4. Get token
@@ -216,7 +217,7 @@ dewy server --registry "ghr://owner/repo?pre-release=true" \
      https://slack.com/api/auth.test
    ```
 2. **Check permissions**
-   - Is `chat:write` set in Bot Token Scopes?
+   - Are `chat:write` and `chat:write.customize` set in Bot Token Scopes?
    - Is the App installed in the workspace?
 3. **Check channel name**
    ```bash


### PR DESCRIPTION
## Summary
- Add `chat:write.customize` scope to Slack OAuth permission requirements in documentation
- Update README (EN/JA) and docs/pages/notifier.md (EN/JA) including permission lists and troubleshooting sections

## Background
Without the `chat:write.customize` scope, the Slack API ignores the `username` and `icon_url` parameters, causing notifications to display the Slack App's default name and icon instead of Dewy's custom bot name and icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)