### PR TITLE
Reduce e2e log noise on success

### DIFF
--- a/e2e/jobs/container-verify.yml
+++ b/e2e/jobs/container-verify.yml
@@ -24,19 +24,24 @@ steps:
 
 - name: Verify containers are not running as root
   id: notroot
-  skipif: vars.runtime == 'podman'
   uses: shell
   with:
     cmd: |
+      runtime="{{ vars.runtime ?? 'docker' }}"
+      # Podman runs rootless by default; skip the check.
+      if [ "$runtime" = "podman" ]; then
+        echo "Skipping non-root check on podman (rootless by default)"
+        exit 0
+      fi
       # Get all container IDs managed by dewy
-      containers=$({{ vars.runtime ?? 'docker' }} ps --filter "label=dewy.managed=true" -q)
+      containers=$($runtime ps --filter "label=dewy.managed=true" -q)
       if [ -z "$containers" ]; then
         echo "No dewy-managed containers found"
         exit 1
       fi
       # Check each container's process user
       for cid in $containers; do
-        uid=$({{ vars.runtime ?? 'docker' }} top "$cid" -o uid | tail -n +2 | head -1 | tr -d ' ')
+        uid=$($runtime top "$cid" -o uid | tail -n +2 | head -1 | tr -d ' ')
         if [ "$uid" = "0" ]; then
           echo "Container $cid is running as root (UID=0)"
           exit 1
@@ -46,7 +51,7 @@ steps:
       echo "All containers are running as non-root user"
   test: status == 0
   outputs:
-    ok: status == 0 || vars.runtime == 'podman'
+    ok: status == 0
 
 - name: Stop dewy
   uses: shell

--- a/e2e/test.yml
+++ b/e2e/test.yml
@@ -633,8 +633,6 @@ jobs:
           --title {{ outputs.genver.version }} \
           --notes "End-to-end Testing by Probe"
     test: status == 0
-    echo: |
-      {{res.stdout}}
   - name: Verify release exists
     uses: shell
     retry:


### PR DESCRIPTION
## Summary

Quiet down two e2e log-noise issues that became more visible after #422 added the shared-cache pair.

- **Podman container verify dumps the full dewy log on success.** The `notroot` step used a step-level `skipif: vars.runtime == 'podman'`, which prevents its `outputs` block from evaluating. The downstream `Show log` step's `skipif` depends on `outputs.notroot.ok` being truthy, so on podman the verify-pass path never reached the skip and dumped the entire dewy log unconditionally. Move the podman branch inside the step's shell command so the step always runs and the output is reliably set.
- **Create release prints the new release URL on every run.** Probe already dumps `stdout`/`stderr` when a step's `test` assertion fails, so the unconditional `echo: {{res.stdout}}` is just noise on success. Remove it; failures still show the gh CLI output via probe's automatic dump.

## Test plan

- [x] Run `/e2e` on this PR. Expected:
  - Podman container verify completes without dumping the dewy log on success.
  - Create new version step does not print the release URL on success.
  - All other assertions still pass (no regression in the verify suite).
- [x] Static check: YAML parses (`ruby -ryaml -e "YAML.load_file('e2e/jobs/container-verify.yml')"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)