### PR TITLE
PR #5: Centralize scheme constants and slot matching

### DIFF
--- a/artifact/artifact.go
+++ b/artifact/artifact.go
@@ -6,13 +6,8 @@ import (
 	"io"
 	"log/slog"
 	"strings"
-)
 
-const (
-	ghrScheme = "ghr"
-	s3Scheme  = "s3"
-	gsScheme  = "gs"
-	imgScheme = "img"
+	"github.com/linyows/dewy/internal/scheme"
 )
 
 // Fetcher is the interface that wraps the Fetch method.
@@ -35,27 +30,33 @@ func WithPuller(p Puller) Option {
 	}
 }
 
+// factoryFn constructs an Artifact from a parsed URL plus the resolved
+// per-call options (puller, etc.).
+type factoryFn func(ctx context.Context, url string, logger *slog.Logger, o *options) (Artifact, error)
+
+var factories = map[string]factoryFn{
+	scheme.GHR: func(ctx context.Context, url string, logger *slog.Logger, _ *options) (Artifact, error) {
+		return NewGHR(ctx, url, logger)
+	},
+	scheme.S3: func(ctx context.Context, url string, logger *slog.Logger, _ *options) (Artifact, error) {
+		return NewS3(ctx, url, logger)
+	},
+	scheme.GS: func(ctx context.Context, url string, logger *slog.Logger, _ *options) (Artifact, error) {
+		return NewGS(ctx, url, logger)
+	},
+	scheme.OCI: func(ctx context.Context, url string, logger *slog.Logger, o *options) (Artifact, error) {
+		return NewOCI(ctx, url, o.puller, logger)
+	},
+}
+
 func New(ctx context.Context, url string, logger *slog.Logger, opts ...Option) (Artifact, error) {
 	var o options
 	for _, opt := range opts {
 		opt(&o)
 	}
-
 	splitted := strings.SplitN(url, "://", 2)
-
-	switch splitted[0] {
-	case ghrScheme:
-		return NewGHR(ctx, url, logger)
-
-	case s3Scheme:
-		return NewS3(ctx, url, logger)
-
-	case gsScheme:
-		return NewGS(ctx, url, logger)
-
-	case imgScheme:
-		return NewOCI(ctx, url, o.puller, logger)
+	if f, ok := factories[splitted[0]]; ok {
+		return f(ctx, url, logger, &o)
 	}
-
 	return nil, fmt.Errorf("unsupported scheme: %s", url)
 }

--- a/artifact/ghr.go
+++ b/artifact/ghr.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-github/v73/github"
 	"github.com/linyows/dewy/client"
+	"github.com/linyows/dewy/internal/scheme"
 )
 
 var (
@@ -29,7 +30,7 @@ type GHR struct {
 
 func NewGHR(ctx context.Context, url string, logger *slog.Logger) (*GHR, error) {
 	// ghr://owner/repo/tag/v1.0.0/artifact.zip
-	splitted := strings.Split(strings.TrimPrefix(url, fmt.Sprintf("%s://", ghrScheme)), "/")
+	splitted := strings.Split(strings.TrimPrefix(url, fmt.Sprintf("%s://", scheme.GHR)), "/")
 	if len(splitted) != 5 {
 		return nil, fmt.Errorf("invalid artifact url: %s, %#v", url, splitted)
 	}

--- a/artifact/gs.go
+++ b/artifact/gs.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+
+	"github.com/linyows/dewy/internal/scheme"
 )
 
 type GS struct {
@@ -26,7 +28,7 @@ func NewGS(ctx context.Context, strUrl string, logger *slog.Logger) (*GS, error)
 		return nil, err
 	}
 
-	if u.Scheme != gsScheme {
+	if u.Scheme != scheme.GS {
 		return nil, fmt.Errorf("unsupported scheme: %s", u.Scheme)
 	}
 

--- a/dewy.go
+++ b/dewy.go
@@ -308,7 +308,7 @@ func (d *Dewy) Run() error {
 	}
 
 	// Check slot matching for blue/green deployment
-	if d.config.Slot != "" && res.Slot != d.config.Slot {
+	if !(registry.SlotMatcher{Expected: d.config.Slot}).Matches(res.Slot) {
 		d.logger.Debug("Deploy skipped: slot mismatch",
 			slog.String("expected_slot", d.config.Slot),
 			slog.String("actual_slot", res.Slot),
@@ -685,7 +685,7 @@ func (d *Dewy) RunContainer() error {
 		slog.String("slot", res.Slot))
 
 	// Check slot matching for blue/green deployment
-	if d.config.Slot != "" && res.Slot != d.config.Slot {
+	if !(registry.SlotMatcher{Expected: d.config.Slot}).Matches(res.Slot) {
 		d.logger.Debug("Deploy skipped: slot mismatch",
 			slog.String("expected_slot", d.config.Slot),
 			slog.String("actual_slot", res.Slot),

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -1,0 +1,12 @@
+// Package scheme defines the URL scheme strings shared between the registry
+// and artifact factories. Centralising the names prevents drift between the
+// two factories (which historically duplicated the same set of constants).
+package scheme
+
+const (
+	GHR  = "ghr"  // GitHub Releases
+	S3   = "s3"   // Amazon S3
+	GS   = "gs"   // Google Cloud Storage
+	GRPC = "grpc" // gRPC registry endpoint
+	OCI  = "img"  // OCI / container image registry
+)

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -1,5 +1,5 @@
 // Package scheme defines the URL scheme strings shared between the registry
-// and artifact factories. Centralising the names prevents drift between the
+// and artifact factories. Centralizing the names prevents drift between the
 // two factories (which historically duplicated the same set of constants).
 package scheme
 

--- a/registry/ghr.go
+++ b/registry/ghr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-github/v73/github"
 	"github.com/google/go-querystring/query"
 	"github.com/linyows/dewy/client"
+	"github.com/linyows/dewy/internal/scheme"
 	"github.com/linyows/dewy/logging"
 )
 
@@ -159,7 +160,7 @@ func (g *GHR) Current(ctx context.Context) (*CurrentResponse, error) {
 		g.logger.Debug("Fetched artifact", slog.String("name", artifactName))
 	}
 
-	au := fmt.Sprintf("%s://%s/%s/tag/%s/%s", ghrScheme, g.Owner, g.Repo, release.GetTagName(), artifactName)
+	au := fmt.Sprintf("%s://%s/%s/tag/%s/%s", scheme.GHR, g.Owner, g.Repo, release.GetTagName(), artifactName)
 
 	// Extract slot from build metadata
 	slot := extractSlot(release.GetTagName(), g.CalVer)

--- a/registry/gs.go
+++ b/registry/gs.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/linyows/dewy/internal/scheme"
 	"github.com/linyows/dewy/logging"
 	"google.golang.org/api/iterator"
 )
@@ -146,7 +147,7 @@ func (g *GS) Current(ctx context.Context) (*CurrentResponse, error) {
 }
 
 func (g *GS) buildArtifactURL(name string) string {
-	return fmt.Sprintf("%s://%s/%s", gsScheme, g.Bucket, name)
+	return fmt.Sprintf("%s://%s/%s", scheme.GS, g.Bucket, name)
 }
 
 // Report report shipping.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -7,17 +7,34 @@ import (
 	"time"
 
 	"github.com/gorilla/schema"
+	"github.com/linyows/dewy/internal/scheme"
 	"github.com/linyows/dewy/logging"
 )
 
-var (
-	decoder    = schema.NewDecoder()
-	s3Scheme   = "s3"
-	ghrScheme  = "ghr"
-	grpcScheme = "grpc"
-	gsScheme   = "gs"
-	imgScheme  = "img"
-)
+var decoder = schema.NewDecoder()
+
+// factoryFn constructs a Registry from a parsed URL. logger is optional
+// (NewGRPC ignores it) but kept in the signature so all registries plug into
+// the same dispatch table.
+type factoryFn func(ctx context.Context, url string, log *logging.Logger) (Registry, error)
+
+var factories = map[string]factoryFn{
+	scheme.GHR: func(ctx context.Context, url string, log *logging.Logger) (Registry, error) {
+		return NewGHR(ctx, url, log)
+	},
+	scheme.S3: func(ctx context.Context, url string, log *logging.Logger) (Registry, error) {
+		return NewS3(ctx, url, log)
+	},
+	scheme.GS: func(ctx context.Context, url string, log *logging.Logger) (Registry, error) {
+		return NewGS(ctx, url, log)
+	},
+	scheme.GRPC: func(ctx context.Context, url string, _ *logging.Logger) (Registry, error) {
+		return NewGRPC(ctx, url)
+	},
+	scheme.OCI: func(ctx context.Context, url string, log *logging.Logger) (Registry, error) {
+		return NewOCI(ctx, url, log)
+	},
+}
 
 type Registry interface {
 	// Current returns the current artifact.
@@ -56,24 +73,9 @@ type ReportRequest struct {
 
 func New(ctx context.Context, url string, log *logging.Logger) (Registry, error) {
 	splitted := strings.SplitN(url, "://", 2)
-
-	switch splitted[0] {
-	case ghrScheme:
-		return NewGHR(ctx, url, log)
-
-	case s3Scheme:
-		return NewS3(ctx, url, log)
-
-	case gsScheme:
-		return NewGS(ctx, url, log)
-
-	case grpcScheme:
-		return NewGRPC(ctx, url)
-
-	case imgScheme:
-		return NewOCI(ctx, url, log)
+	if f, ok := factories[splitted[0]]; ok {
+		return f(ctx, url, log)
 	}
-
 	return nil, fmt.Errorf("unsupported registry: %s", url)
 }
 

--- a/registry/s3.go
+++ b/registry/s3.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	awslogging "github.com/aws/smithy-go/logging"
+	"github.com/linyows/dewy/internal/scheme"
 	"github.com/linyows/dewy/logging"
 )
 
@@ -176,7 +177,7 @@ func (s *S3) buildArtifactURL(key string) string {
 		qstr = "?" + strings.Join(q, "&")
 	}
 
-	return fmt.Sprintf("%s://%s/%s/%s%s", s3Scheme, s.Region, s.Bucket, key, qstr)
+	return fmt.Sprintf("%s://%s/%s/%s%s", scheme.S3, s.Region, s.Bucket, key, qstr)
 }
 
 // Report report shipping.

--- a/registry/slot.go
+++ b/registry/slot.go
@@ -4,7 +4,7 @@ package registry
 // instance's configured slot constraint. An empty Expected matches anything;
 // otherwise the actual slot must match exactly.
 //
-// Centralising this check keeps blue/green slot semantics in one place even
+// Centralizing this check keeps blue/green slot semantics in one place even
 // though the comparison itself is trivial.
 type SlotMatcher struct {
 	Expected string

--- a/registry/slot.go
+++ b/registry/slot.go
@@ -1,0 +1,16 @@
+package registry
+
+// SlotMatcher decides whether a registry response's slot satisfies a Dewy
+// instance's configured slot constraint. An empty Expected matches anything;
+// otherwise the actual slot must match exactly.
+//
+// Centralising this check keeps blue/green slot semantics in one place even
+// though the comparison itself is trivial.
+type SlotMatcher struct {
+	Expected string
+}
+
+// Matches reports whether actual satisfies the matcher.
+func (m SlotMatcher) Matches(actual string) bool {
+	return m.Expected == "" || m.Expected == actual
+}

--- a/registry/slot_test.go
+++ b/registry/slot_test.go
@@ -1,0 +1,23 @@
+package registry
+
+import "testing"
+
+func TestSlotMatcherMatches(t *testing.T) {
+	tests := []struct {
+		expected string
+		actual   string
+		want     bool
+	}{
+		{"", "", true},
+		{"", "blue", true},
+		{"blue", "blue", true},
+		{"blue", "green", false},
+		{"blue", "", false},
+	}
+	for _, tt := range tests {
+		m := SlotMatcher{Expected: tt.expected}
+		if got := m.Matches(tt.actual); got != tt.want {
+			t.Errorf("SlotMatcher{%q}.Matches(%q) = %v, want %v", tt.expected, tt.actual, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two related sources of duplication get cleaned up:

1. **Scheme strings duplicated across two factories**
   `\"ghr\"`, `\"s3\"`, `\"gs\"`, `\"grpc\"`, `\"img\"` were defined independently in `registry/registry.go` and `artifact/artifact.go`. Adding a new scheme required two files to stay in sync. They now live in `internal/scheme` and are imported by both factories, plus the URL-building call sites in `registry/{ghr,gs,s3}.go` and `artifact/{ghr,gs}.go`.

2. **Slot matching scattered between dewy.go and registry/**
   Blue/green slot filtering was inlined twice in `dewy.go` (Run and RunContainer paths) as `if d.config.Slot != \"\" && res.Slot != d.config.Slot`. Extracted into `registry.SlotMatcher{Expected}.Matches(actual)` so the matching rule lives next to the slot extraction in `registry/`.

## Bonus: registry / artifact factories use map dispatch

`registry.New` and `artifact.New` both grow a small map-based factory dispatch in place of the switch statements. Each scheme registers exactly once. This is preparation for adding test-only scheme implementations later (e.g., a stub registry for unit-testing deploy phases without a real GHR / S3 backend).

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] New `registry/slot_test.go`: 5 cases (empty matches anything, exact match, mismatch, etc.)
- [x] Existing `registry/registry_test.go` and `artifact/artifact_test.go` still pass — dispatch behaviour unchanged.
- [x] `gofmt -l .` clean for new files

## Compatibility

- Internal-only changes. Scheme strings (`ghr://`, `s3://`, `gs://`, `grpc://`, `img://`) are unchanged on the wire.
- `SlotMatcher`'s zero value (`Expected: \"\"`) preserves the old \"no slot configured = match anything\" behaviour exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)