### PR TITLE
PR #4: Replace BackendCallback struct with BackendUpdater interface

### DIFF
--- a/container/backend_updater_test.go
+++ b/container/backend_updater_test.go
@@ -1,0 +1,78 @@
+package container
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// mockBackendUpdater records every Add/Remove call and optionally returns an
+// error from AddBackend (for rollback-path coverage in deeper tests).
+type mockBackendUpdater struct {
+	mu      sync.Mutex
+	adds    []backendCall
+	removes []backendCall
+	addErr  error
+}
+
+type backendCall struct {
+	Host       string
+	MappedPort int
+	ProxyPort  int
+}
+
+func (m *mockBackendUpdater) AddBackend(host string, mappedPort, proxyPort int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.adds = append(m.adds, backendCall{host, mappedPort, proxyPort})
+	return m.addErr
+}
+
+func (m *mockBackendUpdater) RemoveBackend(host string, mappedPort, proxyPort int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removes = append(m.removes, backendCall{host, mappedPort, proxyPort})
+	return nil
+}
+
+// Compile-time check that mockBackendUpdater satisfies the public interface.
+var _ BackendUpdater = (*mockBackendUpdater)(nil)
+
+func TestNoopBackendUpdaterReturnsNil(t *testing.T) {
+	// noopBackendUpdater is the substitute Deploy uses when callers pass nil.
+	// The contract is "never panic, always return nil".
+	u := noopBackendUpdater{}
+	if err := u.AddBackend("h", 1, 2); err != nil {
+		t.Errorf("AddBackend returned %v, want nil", err)
+	}
+	if err := u.RemoveBackend("h", 1, 2); err != nil {
+		t.Errorf("RemoveBackend returned %v, want nil", err)
+	}
+}
+
+func TestNoopBackendUpdaterImplementsInterface(t *testing.T) {
+	var _ BackendUpdater = noopBackendUpdater{}
+}
+
+func TestMockBackendUpdaterRecordsCalls(t *testing.T) {
+	// Sanity-check the test mock: future PRs that exercise Deploy behavior
+	// will rely on Calls() ordering and the addErr injection.
+	m := &mockBackendUpdater{}
+	if err := m.AddBackend("a", 1, 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.RemoveBackend("b", 2, 200); err != nil {
+		t.Fatal(err)
+	}
+	if len(m.adds) != 1 || m.adds[0] != (backendCall{"a", 1, 100}) {
+		t.Errorf("adds = %+v", m.adds)
+	}
+	if len(m.removes) != 1 || m.removes[0] != (backendCall{"b", 2, 200}) {
+		t.Errorf("removes = %+v", m.removes)
+	}
+
+	m.addErr = errors.New("boom")
+	if err := m.AddBackend("c", 3, 300); err == nil {
+		t.Error("expected addErr to be returned")
+	}
+}

--- a/container/container.go
+++ b/container/container.go
@@ -107,8 +107,21 @@ type DeployReport struct {
 	RemovedCount int
 }
 
-// BackendCallback provides hooks for proxy backend management during deployment.
-type BackendCallback struct {
-	OnAdd    func(host string, mappedPort int, proxyPort int) error
-	OnRemove func(host string, mappedPort int, proxyPort int) error
+// BackendUpdater is the rolling-deploy hook into the dewy reverse proxy.
+// Deploy calls AddBackend after each new replica passes its health check and
+// RemoveBackend before each old replica is stopped.
+//
+// Deploy treats a nil updater as a no-op, so callers that have no proxy to
+// update (e.g. tests that exercise only container lifecycle) can pass nil.
+type BackendUpdater interface {
+	AddBackend(host string, mappedPort, proxyPort int) error
+	RemoveBackend(host string, mappedPort, proxyPort int) error
 }
+
+// noopBackendUpdater is the default updater used when nil is passed to Deploy.
+// It is unexported because callers should pass nil rather than constructing
+// one explicitly.
+type noopBackendUpdater struct{}
+
+func (noopBackendUpdater) AddBackend(string, int, int) error    { return nil }
+func (noopBackendUpdater) RemoveBackend(string, int, int) error { return nil }

--- a/container/runtime.go
+++ b/container/runtime.go
@@ -464,9 +464,13 @@ func (r *Runtime) FindContainersByLabel(ctx context.Context, labels map[string]s
 }
 
 // Deploy performs a rolling deployment of containers.
-// It starts new containers one by one, runs health checks, updates backends via callback,
-// and then removes old containers.
-func (r *Runtime) Deploy(ctx context.Context, opts RollingDeployOptions, cb BackendCallback) (*DeployReport, error) {
+// It starts new containers one by one, runs health checks, updates backends
+// via the BackendUpdater hook, and then removes old containers. Pass nil for
+// updater when no proxy interaction is needed.
+func (r *Runtime) Deploy(ctx context.Context, opts RollingDeployOptions, updater BackendUpdater) (*DeployReport, error) {
+	if updater == nil {
+		updater = noopBackendUpdater{}
+	}
 	replicas := opts.Replicas
 	if replicas <= 0 {
 		replicas = 1
@@ -501,22 +505,20 @@ func (r *Runtime) Deploy(ctx context.Context, opts RollingDeployOptions, cb Back
 			r.logger.Error("Failed to start container, rolling back",
 				slog.Int("replica", i+1),
 				slog.String("error", err.Error()))
-			r.rollback(ctx, results, cb)
+			r.rollback(ctx, results, updater)
 			return nil, err
 		}
 
 		// Add all port mappings to proxy backends
-		if cb.OnAdd != nil {
-			for proxyPort, mappedPort := range result.MappedPorts {
-				if err := cb.OnAdd("localhost", mappedPort, proxyPort); err != nil {
-					r.logger.Error("Failed to add proxy backend",
-						slog.Int("proxy_port", proxyPort),
-						slog.Int("mapped_port", mappedPort),
-						slog.String("error", err.Error()))
-					// Include current result in rollback to clean up its container and backends
-					r.rollback(ctx, append(results, result), cb)
-					return nil, err
-				}
+		for proxyPort, mappedPort := range result.MappedPorts {
+			if err := updater.AddBackend("localhost", mappedPort, proxyPort); err != nil {
+				r.logger.Error("Failed to add proxy backend",
+					slog.Int("proxy_port", proxyPort),
+					slog.Int("mapped_port", mappedPort),
+					slog.String("error", err.Error()))
+				// Include current result in rollback to clean up its container and backends
+				r.rollback(ctx, append(results, result), updater)
+				return nil, err
 			}
 		}
 
@@ -536,16 +538,14 @@ func (r *Runtime) Deploy(ctx context.Context, opts RollingDeployOptions, cb Back
 			slog.String("container", oldContainerID))
 
 		// Remove from proxy backends
-		if cb.OnRemove != nil {
-			for _, mapping := range opts.PortMappings {
-				oldPort, err := r.GetMappedPort(ctx, oldContainerID, mapping.ContainerPort)
-				if err == nil {
-					if err := cb.OnRemove("localhost", oldPort, mapping.ProxyPort); err != nil {
-						r.logger.Warn("Failed to remove old backend from proxy",
-							slog.Int("proxy_port", mapping.ProxyPort),
-							slog.Int("mapped_port", oldPort),
-							slog.String("error", err.Error()))
-					}
+		for _, mapping := range opts.PortMappings {
+			oldPort, err := r.GetMappedPort(ctx, oldContainerID, mapping.ContainerPort)
+			if err == nil {
+				if err := updater.RemoveBackend("localhost", oldPort, mapping.ProxyPort); err != nil {
+					r.logger.Warn("Failed to remove old backend from proxy",
+						slog.Int("proxy_port", mapping.ProxyPort),
+						slog.Int("mapped_port", oldPort),
+						slog.String("error", err.Error()))
 				}
 			}
 		}
@@ -655,19 +655,19 @@ func (r *Runtime) startAndCheck(ctx context.Context, opts RollingDeployOptions, 
 }
 
 // rollback removes all newly deployed containers and their proxy backends.
-func (r *Runtime) rollback(ctx context.Context, results []DeployResult, cb BackendCallback) {
+// updater is assumed non-nil — callers (Deploy) substitute the noop updater
+// before calling.
+func (r *Runtime) rollback(ctx context.Context, results []DeployResult, updater BackendUpdater) {
 	r.logger.Info("Rolling back containers", slog.Int("count", len(results)))
 
 	// Remove from proxy backends first
-	if cb.OnRemove != nil {
-		for _, result := range results {
-			for proxyPort, mappedPort := range result.MappedPorts {
-				if err := cb.OnRemove("localhost", mappedPort, proxyPort); err != nil {
-					r.logger.Warn("Failed to remove backend during rollback",
-						slog.Int("proxy_port", proxyPort),
-						slog.Int("mapped_port", mappedPort),
-						slog.String("error", err.Error()))
-				}
+	for _, result := range results {
+		for proxyPort, mappedPort := range result.MappedPorts {
+			if err := updater.RemoveBackend("localhost", mappedPort, proxyPort); err != nil {
+				r.logger.Warn("Failed to remove backend during rollback",
+					slog.Int("proxy_port", proxyPort),
+					slog.Int("mapped_port", mappedPort),
+					slog.String("error", err.Error()))
 			}
 		}
 	}

--- a/dewy.go
+++ b/dewy.go
@@ -591,7 +591,7 @@ func (d *Dewy) deployContainer(ctx context.Context, res *registry.CurrentRespons
 	// Create health check function (telemetry-aware, stays in dewy.go)
 	healthCheck := d.createHealthCheckFunc(runtime, resolvedMappings)
 
-	// Deploy via container runtime
+	// Deploy via container runtime, with the dewy proxy as the BackendUpdater.
 	report, err := runtime.Deploy(ctx, container.RollingDeployOptions{
 		ImageRef:     imageRef,
 		AppName:      appName,
@@ -600,14 +600,7 @@ func (d *Dewy) deployContainer(ctx context.Context, res *registry.CurrentRespons
 		Command:      d.config.Container.Command,
 		ExtraArgs:    d.config.Container.ExtraArgs,
 		HealthCheck:  healthCheck,
-	}, container.BackendCallback{
-		OnAdd: func(host string, mappedPort, proxyPort int) error {
-			return d.addProxyBackend(host, mappedPort, proxyPort)
-		},
-		OnRemove: func(host string, mappedPort, proxyPort int) error {
-			return d.removeProxyBackend(host, mappedPort, proxyPort)
-		},
-	})
+	}, (*proxyBackendUpdater)(d))
 	if err != nil {
 		return 0, err
 	}
@@ -918,6 +911,23 @@ func (p *tcpProxy) backendCount() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return len(p.backends)
+}
+
+// proxyBackendUpdater adapts *Dewy to the container.BackendUpdater interface
+// so the rolling deploy can register/unregister TCP-proxy backends as new
+// replicas come up and old replicas are taken down.
+//
+// The type alias on *Dewy (rather than a wrapper struct) keeps zero indirection
+// and avoids capturing closures: passing (*proxyBackendUpdater)(d) to Deploy
+// is the entire glue.
+type proxyBackendUpdater Dewy
+
+func (p *proxyBackendUpdater) AddBackend(host string, mappedPort, proxyPort int) error {
+	return (*Dewy)(p).addProxyBackend(host, mappedPort, proxyPort)
+}
+
+func (p *proxyBackendUpdater) RemoveBackend(host string, mappedPort, proxyPort int) error {
+	return (*Dewy)(p).removeProxyBackend(host, mappedPort, proxyPort)
 }
 
 // addProxyBackend adds a new backend to the appropriate TCP proxy.

--- a/proxy_backend_updater_test.go
+++ b/proxy_backend_updater_test.go
@@ -1,0 +1,40 @@
+package dewy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/linyows/dewy/container"
+)
+
+// proxyBackendUpdater must satisfy container.BackendUpdater so it can be
+// passed straight to runtime.Deploy.
+func TestProxyBackendUpdaterImplementsInterface(t *testing.T) {
+	d := newPhaseTestDewy(t)
+	var _ container.BackendUpdater = (*proxyBackendUpdater)(d)
+}
+
+// AddBackend / RemoveBackend forward to addProxyBackend / removeProxyBackend.
+// Without a real tcpProxy registered for the port, both methods surface an
+// error path so we can assert the forwarding happened and the wiring is alive.
+func TestProxyBackendUpdaterForwardsToDewy(t *testing.T) {
+	d := newPhaseTestDewy(t)
+	d.tcpProxies = nil // explicit empty
+	u := (*proxyBackendUpdater)(d)
+
+	err := u.AddBackend("localhost", 9001, 8080)
+	if err == nil {
+		t.Fatal("expected error when no proxy is configured for the port, got nil")
+	}
+	if !strings.Contains(err.Error(), "8080") {
+		t.Errorf("error %q should mention the missing proxy port 8080", err)
+	}
+
+	err = u.RemoveBackend("localhost", 9001, 8080)
+	if err == nil {
+		t.Fatal("expected error when no proxy is configured for the port, got nil")
+	}
+	if !strings.Contains(err.Error(), "8080") {
+		t.Errorf("error %q should mention the missing proxy port 8080", err)
+	}
+}


### PR DESCRIPTION
## Summary

`container.Deploy()` previously took a `BackendCallback` struct with two function fields (`OnAdd`, `OnRemove`). Each call site in `runtime.go` had to guard against the field being nil before invoking it, and the dewy package built closures over `addProxyBackend` / `removeProxyBackend` to populate the struct.

This PR replaces the struct with a small `BackendUpdater` interface:

```go
type BackendUpdater interface {
    AddBackend(host string, mappedPort, proxyPort int) error
    RemoveBackend(host string, mappedPort, proxyPort int) error
}
```

`Deploy` substitutes a private `noopBackendUpdater{}` when nil is passed, so the per-call-site nil checks go away. The dewy-side closure dance collapses to a single zero-cost type cast — a new `proxyBackendUpdater` type alias on `*Dewy` lets the rolling deploy talk to the TCP proxy via the existing methods with no captured closures.

## Why this matters

- Removes a small but persistent source of nil-check noise in `runtime.Deploy` and `runtime.rollback`.
- Cleans up the dewy / container interface boundary: a single named type instead of an anonymous `BackendCallback{ OnAdd: func(...){}, OnRemove: func(...){} }` literal.
- Sets up the next steps (PR #6 file split, future Deploy unit tests against a `mockBackendUpdater`).

## Tests added

- `container/backend_updater_test.go`
  - `TestNoopBackendUpdaterReturnsNil` / `_ImplementsInterface` — contract for the nil-substitution path
  - `TestMockBackendUpdaterRecordsCalls` — sanity check on the recording mock that future Deploy-behavior tests will use
- `proxy_backend_updater_test.go`
  - `TestProxyBackendUpdaterImplementsInterface` — compile-time check
  - `TestProxyBackendUpdaterForwardsToDewy` — verifies AddBackend / RemoveBackend forward to the underlying Dewy methods (proven by a missing-port error)

## Compatibility

- Internal-only refactor. Container deploy semantics, ordering of add/remove calls during rolling deploy, and rollback flow are all unchanged.
- The single external caller (`dewy.go`) was updated atomically in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)