### PR TITLE
PR #7: Remove dead DisableRecordShipping field

### DIFF
--- a/registry/ghr.go
+++ b/registry/ghr.go
@@ -51,14 +51,13 @@ const (
 
 // GHR struct.
 type GHR struct {
-	Owner                 string `schema:"-"`
-	Repo                  string `schema:"-"`
-	Artifact              string `schema:"artifact"`
-	PreRelease            bool   `schema:"pre-release"`
-	CalVer                string `schema:"calver"`
-	DisableRecordShipping bool   // FIXME: For testing. Remove this.
-	cl                    *github.Client
-	logger                *logging.Logger
+	Owner      string `schema:"-"`
+	Repo       string `schema:"-"`
+	Artifact   string `schema:"artifact"`
+	PreRelease bool   `schema:"pre-release"`
+	CalVer     string `schema:"calver"`
+	cl         *github.Client
+	logger     *logging.Logger
 }
 
 // New returns GHR.


### PR DESCRIPTION
## Summary

`GHR.DisableRecordShipping` was marked `// FIXME: For testing. Remove this.` and is **no longer referenced anywhere in the tree**:

- No setter (no `gh.DisableRecordShipping = true` anywhere)
- No reader (no production code conditioned on it)
- Not used by any current test

It outlived whatever test originally relied on it. The plan called for migrating GHR to a `WithHTTPClient` functional option, but since the field is genuinely dead, the simpler fix is to just remove it.

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `git grep DisableRecordShipping` returns nothing

## Compatibility

- Internal-only refactor.
- The `GHR` struct exposes its name through schema tags; this field had no schema tag, so removing it has no effect on URL parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)