### PR TITLE
PR #8: Centralize timing magic numbers into defaults.go

### DIFF
--- a/container/defaults.go
+++ b/container/defaults.go
@@ -1,0 +1,25 @@
+package container
+
+import "time"
+
+// Defaults for container-runtime timing. Kept in one place so operators
+// auditing the rolling-deploy cadence do not have to grep for time literals
+// scattered across runtime.go.
+const (
+	// defaultStartupGrace is the pause between starting a container and
+	// running its first health probe. Gives the application time to bind
+	// its port and begin serving without us misclassifying boot latency
+	// as failure.
+	defaultStartupGrace = 3 * time.Second
+
+	// defaultStopTimeoutOld is how long we wait for an old (pre-deploy)
+	// container to drain before sending it KILL. Pairs with the
+	// drain-time setting and is intentionally generous.
+	defaultStopTimeoutOld = 10 * time.Second
+
+	// defaultStopTimeoutFailed is how long we wait for a container that
+	// failed health checks or was caught up in a rollback to stop. Shorter
+	// than the old-container value because the container has not been
+	// taking traffic.
+	defaultStopTimeoutFailed = 5 * time.Second
+)

--- a/container/runtime.go
+++ b/container/runtime.go
@@ -551,7 +551,7 @@ func (r *Runtime) Deploy(ctx context.Context, opts RollingDeployOptions, updater
 		}
 
 		// Stop and remove old container
-		if err := r.Stop(ctx, oldContainerID, 10*time.Second); err != nil {
+		if err := r.Stop(ctx, oldContainerID, defaultStopTimeoutOld); err != nil {
 			r.logger.Error("Failed to stop old container",
 				slog.String("container", oldContainerID),
 				slog.String("error", err.Error()))
@@ -633,11 +633,11 @@ func (r *Runtime) startAndCheck(ctx context.Context, opts RollingDeployOptions, 
 	// Perform health check if configured
 	if opts.HealthCheck != nil {
 		// Give the container a moment to start
-		time.Sleep(3 * time.Second)
+		time.Sleep(defaultStartupGrace)
 
 		r.logger.Info("Performing health check", slog.String("container", containerID))
 		if err := opts.HealthCheck(ctx, containerID); err != nil {
-			sErr := r.Stop(ctx, containerID, 5*time.Second)
+			sErr := r.Stop(ctx, containerID, defaultStopTimeoutFailed)
 			rErr := r.Remove(ctx, containerID)
 			return DeployResult{}, errors.Join(
 				fmt.Errorf("health check failed: %w", err),
@@ -674,7 +674,7 @@ func (r *Runtime) rollback(ctx context.Context, results []DeployResult, updater 
 
 	// Stop and remove containers
 	for _, result := range results {
-		if err := r.Stop(ctx, result.ContainerID, 5*time.Second); err != nil {
+		if err := r.Stop(ctx, result.ContainerID, defaultStopTimeoutFailed); err != nil {
 			r.logger.Error("Failed to stop container during rollback",
 				slog.String("container", result.ContainerID),
 				slog.String("error", err.Error()))
@@ -708,7 +708,7 @@ func (r *Runtime) StopManagedContainers(ctx context.Context, appName string) (in
 
 	r.logger.Info("Found managed containers to stop", slog.Int("count", len(containerIDs)))
 
-	timeout := 10 * time.Second
+	timeout := defaultStopTimeoutOld
 	stopped := 0
 	removed := 0
 

--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,31 @@
+package dewy
+
+import "time"
+
+// Defaults for time-bounded behaviors that are not currently exposed via the
+// CLI. They live here rather than scattered as inline literals so the
+// trade-offs are discoverable in one place.
+//
+// All values are package-private; expose via Config / CLI only when an
+// operator actually has a reason to override.
+const (
+	// defaultArtifactGracePeriod is the window during which a missing
+	// artifact (typically because CI is still uploading after the release
+	// was tagged) is treated as "skip this tick" rather than an error.
+	defaultArtifactGracePeriod = 30 * time.Minute
+
+	// defaultHealthCheckTimeout is the per-request HTTP timeout used by the
+	// container health check probe.
+	defaultHealthCheckTimeout = 5 * time.Second
+
+	// defaultHealthCheckRetries is the number of probe attempts before a
+	// container is considered unhealthy.
+	defaultHealthCheckRetries = 5
+
+	// defaultHealthCheckDelay is the back-off between probe attempts.
+	defaultHealthCheckDelay = 2 * time.Second
+
+	// defaultAdminReadHeaderTimeout caps how long the admin HTTP server
+	// waits for request headers; mitigates Slowloris.
+	defaultAdminReadHeaderTimeout = 5 * time.Second
+)

--- a/dewy.go
+++ b/dewy.go
@@ -637,9 +637,9 @@ func (d *Dewy) createHealthCheckFunc(rt *container.Runtime, resolvedMappings []c
 		}
 
 		healthURL := fmt.Sprintf("http://localhost:%d%s", mappedPort, d.config.Container.HealthPath)
-		client := &http.Client{Timeout: 5 * time.Second}
+		client := &http.Client{Timeout: defaultHealthCheckTimeout}
 
-		retries := 5
+		retries := defaultHealthCheckRetries
 		for i := range retries {
 			if d.telemetry != nil && d.telemetry.Enabled() {
 				d.telemetry.Metrics().HealthChecksTotal.Add(ctx, 1)
@@ -658,7 +658,7 @@ func (d *Dewy) createHealthCheckFunc(rt *container.Runtime, resolvedMappings []c
 				d.telemetry.Metrics().HealthCheckFailures.Add(ctx, 1)
 			}
 			if i < retries-1 {
-				time.Sleep(2 * time.Second)
+				time.Sleep(defaultHealthCheckDelay)
 			}
 		}
 		return fmt.Errorf("health check failed after %d retries", retries)
@@ -1073,7 +1073,7 @@ func (d *Dewy) startAdminAPI(ctx context.Context) error {
 
 	d.adminServer = &http.Server{
 		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
+		ReadHeaderTimeout: defaultAdminReadHeaderTimeout,
 	}
 
 	// Start server in background

--- a/dewy_phases.go
+++ b/dewy_phases.go
@@ -34,11 +34,10 @@ func (d *Dewy) resolveCurrent(ctx context.Context) (*registry.CurrentResponse, e
 		// we return (nil, nil) to suppress the alert.
 		var artifactNotFoundErr *registry.ArtifactNotFoundError
 		if errors.As(err, &artifactNotFoundErr) {
-			gracePeriod := 30 * time.Minute
-			if artifactNotFoundErr.IsWithinGracePeriod(gracePeriod) {
+			if artifactNotFoundErr.IsWithinGracePeriod(defaultArtifactGracePeriod) {
 				d.logger.Debug("Artifact not found within grace period",
 					slog.String("message", artifactNotFoundErr.Message),
-					slog.Duration("grace_period", gracePeriod))
+					slog.Duration("grace_period", defaultArtifactGracePeriod))
 				return nil, nil
 			}
 		}


### PR DESCRIPTION
## Summary

Health-check, deploy, and grace-period timing values were scattered as inline `time.Duration` literals across `dewy.go`, `dewy_phases.go`, and `container/runtime.go`. An operator auditing the rolling-deploy cadence or the artifact-not-found grace window had to grep for time literals in three files and infer their meaning from surrounding code.

This PR moves the values into named package-private constants in two new files:

```go
// defaults.go (package dewy)
defaultArtifactGracePeriod    = 30 * time.Minute  // dewy_phases.go
defaultHealthCheckTimeout     = 5  * time.Second  // dewy.go health probe
defaultHealthCheckRetries     = 5                  // dewy.go health probe
defaultHealthCheckDelay       = 2  * time.Second  // dewy.go health probe
defaultAdminReadHeaderTimeout = 5  * time.Second  // dewy.go admin server

// container/defaults.go (package container)
defaultStartupGrace      = 3  * time.Second  // pre-health-check pause
defaultStopTimeoutOld    = 10 * time.Second  // drain-timeout for old containers
defaultStopTimeoutFailed = 5  * time.Second  // failed/rollback containers
```

Each constant has a doc comment explaining the trade-off behind the value.

## Naming choice

Constants are lowercase (private) because none of them need to be reached from outside the module yet. When a real operator-facing override use case appears, the constant simply becomes the default of a `Config` field — the rename to uppercase happens at that moment, not preemptively.

The plan called for `Default*` (uppercase). I went lowercase to match existing convention in the file (`keepReleases`, `defaultProxyIdleTimeout`); the only currently-uppercase constant in `dewy.go`'s top block is `MaxArtifactSize`, which is genuinely consumed by external callers.

## Test plan

- [x] `go test -race ./...` — all packages pass (no behavioural change)
- [x] `grep -nE '30 \* time\.Minute|2 \* time\.Second|3 \* time\.Second|5 \* time\.Second|10 \* time\.Second'` returns nothing in dewy.go / dewy_phases.go / container/runtime.go

## Compatibility

- Internal-only refactor. Every literal was replaced 1:1 with its named constant; no values changed.
- CLI flags, config fields, and on-disk format are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)