### PR TITLE
Rename inspect structs to noun form, drop redundant prefix

### DIFF
--- a/container/image.go
+++ b/container/image.go
@@ -12,8 +12,10 @@ import (
 	"time"
 )
 
-// imageInspect represents the structure of image inspect JSON output.
-type imageInspect struct {
+// imageInspection represents the structure of `<runtime> image inspect` JSON
+// output. The "image" qualifier distinguishes it from inspection (the
+// container-side default in inspect.go).
+type imageInspection struct {
 	ID     string `json:"Id"`
 	Config struct {
 		ExposedPorts map[string]struct{} `json:"ExposedPorts"`
@@ -255,7 +257,7 @@ func (r *Runtime) GetImageExposedPorts(ctx context.Context, imageRef string) ([]
 		return nil, fmt.Errorf("failed to inspect image: %w", err)
 	}
 
-	var inspects []imageInspect
+	var inspects []imageInspection
 	if err := json.Unmarshal([]byte(output), &inspects); err != nil {
 		return nil, fmt.Errorf("failed to parse image inspect output: %w", err)
 	}

--- a/container/inspect.go
+++ b/container/inspect.go
@@ -9,8 +9,10 @@ import (
 	"time"
 )
 
-// containerInspect represents the structure of container inspect JSON output.
-type containerInspect struct {
+// inspection represents the structure of `<runtime> inspect <container>` JSON
+// output. The "container" qualifier is implicit (the package is container);
+// the image variant is named imageInspection (in image.go).
+type inspection struct {
 	ID      string `json:"Id"`
 	Name    string `json:"Name"`
 	Created string `json:"Created"`
@@ -157,7 +159,7 @@ func (r *Runtime) GetContainerInfo(ctx context.Context, containerID string, cont
 		return nil, fmt.Errorf("failed to inspect container: %w", err)
 	}
 
-	var inspects []containerInspect
+	var inspects []inspection
 	if err := json.Unmarshal([]byte(output), &inspects); err != nil {
 		return nil, fmt.Errorf("failed to parse inspect output: %w", err)
 	}


### PR DESCRIPTION
## Summary

Two paired private types in the container package were named with verb-as-noun form, and the container-side one had a redundant package-name prefix:

```
containerInspect -> inspection      (drop redundant "container" prefix)
imageInspect     -> imageInspection (keep "image" prefix as variant marker; verb to noun)
```

## Why asymmetric

In the container package, **container is the default subject** so it elides; **image is a named variant** so it stays. This mirrors stdlib patterns like `bytes.Buffer` / `bytes.Reader` — the package's central abstraction has no prefix, the variant does.

`inspect` is a verb (`docker inspect` / `podman inspect` is the CLI subcommand). Go conventions favor noun struct names (`json.Decoder`, `http.Request`), so `inspection` reads more naturally for a JSON-shape type.

## Test plan

- [x] `go test -race ./container/...` — pass (compile-only impact)
- [x] `go vet ./...` clean

## Compatibility

Both types are package-private; no external API surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)