### PR TITLE
Make WithClock/WithEnv nil-safe and fix misleading doc

### DIFF
--- a/registry/cached.go
+++ b/registry/cached.go
@@ -64,16 +64,25 @@ type Cached struct {
 // CachedOption configures optional dependencies of a Cached registry.
 type CachedOption func(*Cached)
 
-// WithClock injects a custom Clock. The default is sysdeps.RealClock.
+// WithClock injects a custom Clock. Defaults to sysdeps.RealClock.
+// A nil clock is ignored so the default stays in effect.
 func WithClock(c sysdeps.Clock) CachedOption {
-	return func(x *Cached) { x.clock = c }
+	return func(x *Cached) {
+		if c != nil {
+			x.clock = c
+		}
+	}
 }
 
-// WithEnv injects a custom Env. Used for hostname lookup at construction.
-// Passing this option is only meaningful when paired with NewCachedWithOptions
-// — the default constructor freezes nodeID at New time.
+// WithEnv injects a custom Env. The Env is consulted at NewCached time to
+// derive the refresh-lock node ID (hostname:pid); after construction the
+// node ID is frozen. Defaults to sysdeps.RealEnv. A nil env is ignored.
 func WithEnv(e sysdeps.Env) CachedOption {
-	return func(x *Cached) { x.nodeID = nodeIDFrom(e) }
+	return func(x *Cached) {
+		if e != nil {
+			x.nodeID = nodeIDFrom(e)
+		}
+	}
 }
 
 // NewCached wraps inner with a shared registry-result cache backed by

--- a/registry/cached_test.go
+++ b/registry/cached_test.go
@@ -359,6 +359,24 @@ func TestCachedNodeIDFromEnv(t *testing.T) {
 	}
 }
 
+// Passing nil to WithClock / WithEnv must leave the real defaults installed
+// rather than panicking later inside Current().
+func TestCachedOptionsIgnoreNil(t *testing.T) {
+	upstream := &mockUpstream{tag: "v1.2.3"}
+	fakeCache := newFakeAtomicCache()
+	c := NewCached(upstream, "ghr://x", fakeCache, time.Minute, testLogger(), WithClock(nil), WithEnv(nil))
+	if c.clock == nil {
+		t.Fatal("WithClock(nil) wiped the default clock; expected real clock to remain")
+	}
+	if c.nodeID == "" {
+		t.Fatal("WithEnv(nil) wiped the default nodeID; expected real env to remain")
+	}
+	// Smoke: Current must not panic with the defaults still in place.
+	if _, err := c.Current(context.Background()); err != nil {
+		t.Fatalf("Current after nil options: %v", err)
+	}
+}
+
 func TestCachedReportPassthrough(t *testing.T) {
 	c, upstream, _ := newCachedForTest(t, time.Minute)
 	called := false


### PR DESCRIPTION
## Summary

Two related fixes to `registry.NewCached`'s option set, both surfaced by Copilot review on PR #434:

1. **`WithEnv` doc comment referenced a non-existent constructor.** It said the option is "only meaningful when paired with `NewCachedWithOptions`", but no such function exists — `NewCached` itself takes the options via the variadic. The wording was a leftover from an earlier design.

2. **`WithClock(nil)` and `WithEnv(nil)` would panic.** `WithClock(nil)` previously set `c.clock = nil`, and a later `c.clock.Now()` inside `Current` panicked. Same shape for `WithEnv(nil)`, which would call `Hostname()` on a nil interface inside `nodeIDFrom`. Both options now ignore nil and leave the real defaults that `NewCached` installs by default.

## Test plan

- [x] `go test -race ./registry/...` — pass, including new `TestCachedOptionsIgnoreNil`
- [x] `go vet ./...` clean

## Compatibility

Internal-only behavior fix. No call site has been passing `nil` to either option, so this is purely a defensive cleanup that makes the option contract match its doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)