### PR TITLE
Fix 6 deferred bugs from the refactoring branch

### DIFF
--- a/admin_api.go
+++ b/admin_api.go
@@ -97,6 +97,17 @@ func (d *Dewy) stopAdminAPI(ctx context.Context) error {
 	return nil
 }
 
+// containerListLabels returns the label set the deploy path uses to mark
+// managed containers, so admin queries match the deploy reality even when
+// --name is omitted (in which case appName falls back to the registry-
+// derived repository name).
+func (d *Dewy) containerListLabels() map[string]string {
+	return map[string]string{
+		"dewy.managed": "true",
+		"dewy.app":     d.appName(),
+	}
+}
+
 // handleGetContainers handles GET /api/containers endpoint.
 func (d *Dewy) handleGetContainers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -106,22 +117,20 @@ func (d *Dewy) handleGetContainers(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	// Get containers managed by dewy
-	labels := map[string]string{
-		"dewy.managed": "true",
-		"dewy.app":     d.config.Container.Name,
-	}
-
 	var containers []*container.Info
-	var err error
 
-	if d.config.Command == CONTAINER {
+	// containerRuntime is wired up by the first RunContainer tick. The admin
+	// API listens earlier (in Start()), so a request that lands during the
+	// startup window has nothing to query — return an empty list rather
+	// than nil-deref.
+	if d.config.Command == CONTAINER && d.containerRuntime != nil {
 		// Use first port mapping for listing containers (0 = auto-detect / not specified)
 		containerPort := 0
 		if len(d.config.Container.PortMappings) > 0 {
 			containerPort = d.config.Container.PortMappings[0].ContainerPort
 		}
-		containers, err = d.containerRuntime.ListContainersByLabels(ctx, labels, containerPort)
+		var err error
+		containers, err = d.containerRuntime.ListContainersByLabels(ctx, d.containerListLabels(), containerPort)
 		if err != nil {
 			d.logger.Error("Failed to list containers",
 				slog.String("error", err.Error()))
@@ -156,7 +165,7 @@ func (d *Dewy) handleGetStatus(w http.ResponseWriter, r *http.Request) {
 	// Return JSON response
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]any{
-		"name":            d.config.Container.Name,
+		"name":            d.appName(),
 		"command":         d.config.Command,
 		"current_version": d.cVer,
 		"proxy_backends":  totalBackends,

--- a/admin_api_test.go
+++ b/admin_api_test.go
@@ -1,0 +1,108 @@
+package dewy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newAdminTestDewy returns a Dewy minimally configured for admin-handler
+// tests. Container.Name is left empty so the admin path must fall back to
+// the registry-derived appName.
+func newAdminTestDewy(t *testing.T) *Dewy {
+	t.Helper()
+	c := DefaultConfig()
+	c.Command = CONTAINER
+	c.Registry = "img://ghcr.io/owner/myapp"
+	c.Cache = CacheConfig{Type: FILE, Expiration: 10, URL: "file://" + t.TempDir()}
+	c.Container = &ContainerConfig{Name: ""}
+	d, err := New(c, testLogger())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return d
+}
+
+// Bug #2: when --name is omitted, the deploy path labels containers with the
+// derived app name; the admin API used to filter by an empty value and
+// return 0 containers. The label-building helper must agree with appName().
+func TestContainerListLabels_DerivesAppName(t *testing.T) {
+	d := newAdminTestDewy(t)
+	got := d.containerListLabels()
+	if got["dewy.app"] != "myapp" {
+		t.Errorf(`labels["dewy.app"] = %q, want "myapp" (derived from registry)`, got["dewy.app"])
+	}
+	if got["dewy.managed"] != "true" {
+		t.Errorf(`labels["dewy.managed"] = %q, want "true"`, got["dewy.managed"])
+	}
+}
+
+// Bug #1: startAdminAPI runs in Start() before the first RunContainer tick
+// initialises d.containerRuntime. Hitting /api/containers during that window
+// used to nil-deref. The handler must respond cleanly without panicking.
+func TestHandleGetContainers_NilRuntimeDoesNotPanic(t *testing.T) {
+	d := newAdminTestDewy(t)
+	if d.containerRuntime != nil {
+		t.Fatal("test setup invariant violated: containerRuntime should be nil before the first tick")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/containers", nil)
+	w := httptest.NewRecorder()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleGetContainers panicked with nil runtime: %v", r)
+		}
+	}()
+
+	d.handleGetContainers(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	var body struct {
+		Containers []any `json:"containers"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(body.Containers) != 0 {
+		t.Errorf("containers = %v, want empty list", body.Containers)
+	}
+}
+
+// Bug #3: /api/status used to report Config.Container.Name verbatim, which
+// is empty when --name is omitted. The reported name should match the
+// appName the deploy path actually uses.
+func TestHandleGetStatus_ReportsDerivedAppName(t *testing.T) {
+	d := newAdminTestDewy(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	w := httptest.NewRecorder()
+	d.handleGetStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if name, _ := body["name"].(string); name != "myapp" {
+		t.Errorf(`status.name = %q, want "myapp" (derived from registry); body=%s`, name, w.Body.String())
+	}
+}
+
+// MethodNotAllowed remains. (Sanity check that the new code paths haven't
+// regressed the method gate.)
+func TestHandleGetContainers_RejectsNonGet(t *testing.T) {
+	d := newAdminTestDewy(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/containers", strings.NewReader(""))
+	w := httptest.NewRecorder()
+	d.handleGetContainers(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /api/containers: status = %d, want 405", w.Code)
+	}
+}

--- a/admin_api_test.go
+++ b/admin_api_test.go
@@ -40,7 +40,7 @@ func TestContainerListLabels_DerivesAppName(t *testing.T) {
 }
 
 // Bug #1: startAdminAPI runs in Start() before the first RunContainer tick
-// initialises d.containerRuntime. Hitting /api/containers during that window
+// initializes d.containerRuntime. Hitting /api/containers during that window
 // used to nil-deref. The handler must respond cleanly without panicking.
 func TestHandleGetContainers_NilRuntimeDoesNotPanic(t *testing.T) {
 	d := newAdminTestDewy(t)

--- a/app_name.go
+++ b/app_name.go
@@ -10,7 +10,7 @@ import "strings"
 // container_deploy.go's deployContainer and stopManagedContainers) and was
 // missing from admin_api.go entirely — so /api/containers and /api/status
 // would return empty values when --name was omitted even though the deploy
-// had created containers under the derived name. Centralising it here makes
+// had created containers under the derived name. Centralizing it here makes
 // the deploy / admin / shutdown paths agree by construction.
 func (d *Dewy) appName() string {
 	if d.config.Container != nil && d.config.Container.Name != "" {

--- a/app_name.go
+++ b/app_name.go
@@ -1,0 +1,41 @@
+package dewy
+
+import "strings"
+
+// appName returns the dewy.app label value that this instance's deploys
+// register containers under. Prefers an explicit Config.Container.Name;
+// otherwise derives from the registry URL's last path segment.
+//
+// The fallback used to live inline in three places (lifecycle.go,
+// container_deploy.go's deployContainer and stopManagedContainers) and was
+// missing from admin_api.go entirely — so /api/containers and /api/status
+// would return empty values when --name was omitted even though the deploy
+// had created containers under the derived name. Centralising it here makes
+// the deploy / admin / shutdown paths agree by construction.
+func (d *Dewy) appName() string {
+	if d.config.Container != nil && d.config.Container.Name != "" {
+		return d.config.Container.Name
+	}
+	return deriveAppNameFromRegistry(d.config.Registry)
+}
+
+// deriveAppNameFromRegistry pulls the repository segment out of a registry
+// URL of the form "<scheme>://<host>/<path>?<query>". The last path
+// component, with any tag (`:`) and query (`?`) suffix stripped, is the
+// repository name — which is what dewy uses as the default app name.
+//
+// Returns "" if the URL cannot be parsed enough to find a path component.
+func deriveAppNameFromRegistry(registryURL string) string {
+	parts := strings.SplitN(registryURL, "://", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	pathParts := strings.Split(parts[1], "/")
+	if len(pathParts) == 0 {
+		return ""
+	}
+	last := pathParts[len(pathParts)-1]
+	last = strings.Split(last, "?")[0]
+	last = strings.Split(last, ":")[0]
+	return last
+}

--- a/app_name_test.go
+++ b/app_name_test.go
@@ -1,0 +1,55 @@
+package dewy
+
+import "testing"
+
+// appName must prefer Config.Container.Name when set. The label filter that
+// admin API and stopManagedContainers use must agree with the deploy path.
+func TestAppName_ExplicitName(t *testing.T) {
+	d := &Dewy{config: Config{
+		Container: &ContainerConfig{Name: "myapp"},
+		Registry:  "img://ghcr.io/owner/derived-name",
+	}}
+	if got := d.appName(); got != "myapp" {
+		t.Errorf("appName() = %q, want myapp", got)
+	}
+}
+
+// When Container.Name is empty, fall back to the registry repository segment.
+// This is what the deploy path was already doing (via imageRef parsing); the
+// admin API used to read Config.Container.Name directly and report empty.
+func TestAppName_DerivedFromRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		want     string
+	}{
+		{"OCI ghcr", "img://ghcr.io/owner/myrepo", "myrepo"},
+		{"OCI with query", "img://ghcr.io/owner/myrepo?pre-release=true", "myrepo"},
+		{"OCI with tag", "img://ghcr.io/owner/myrepo:latest", "myrepo"},
+		{"GHR", "ghr://owner/myrepo", "myrepo"},
+		{"GHR with query", "ghr://owner/myrepo?pre-release=true", "myrepo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Dewy{config: Config{
+				Container: &ContainerConfig{Name: ""},
+				Registry:  tt.registry,
+			}}
+			if got := d.appName(); got != tt.want {
+				t.Errorf("appName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// nil Container config (server/assets paths can have it) must not panic; the
+// fallback is the registry-derived name.
+func TestAppName_NilContainerConfig(t *testing.T) {
+	d := &Dewy{config: Config{
+		Container: nil,
+		Registry:  "ghr://owner/myrepo",
+	}}
+	if got := d.appName(); got != "myrepo" {
+		t.Errorf("appName() = %q, want myrepo", got)
+	}
+}

--- a/container/credentials.go
+++ b/container/credentials.go
@@ -13,32 +13,33 @@ import (
 // For images without explicit registry (e.g., "nginx:latest"), returns "docker.io".
 // For images with registry (e.g., "ghcr.io/owner/repo:tag"), returns the registry host.
 func extractRegistry(imageRef string) string {
-	// Remove tag or digest
+	// Strip any digest first (after `@`).
 	ref := imageRef
-	if idx := strings.LastIndex(ref, "@"); idx != -1 {
+	if idx := strings.Index(ref, "@"); idx != -1 {
 		ref = ref[:idx]
 	}
-	if idx := strings.LastIndex(ref, ":"); idx != -1 {
-		// Check if this is a port number (e.g., localhost:5000/image)
-		slashIdx := strings.LastIndex(ref[:idx], "/")
-		if slashIdx == -1 || !strings.Contains(ref[slashIdx:idx], ".") {
-			ref = ref[:idx]
-		}
+
+	// Strip the tag, but only when `:` is unambiguously a tag separator —
+	// i.e. the colon appears after the last `/`. A colon before the last
+	// `/` is part of a `host:port` registry (e.g. `localhost:5000/img`)
+	// and must be preserved.
+	lastSlash := strings.LastIndex(ref, "/")
+	lastColon := strings.LastIndex(ref, ":")
+	if lastColon > lastSlash {
+		ref = ref[:lastColon]
 	}
 
-	// Check if the first part contains a dot or colon (indicating a registry)
+	// First component is the registry only if it contains a dot, a colon
+	// (host:port), or is the literal "localhost". Otherwise it is the user
+	// part of an implicit Docker Hub reference (e.g. "library/nginx").
 	parts := strings.SplitN(ref, "/", 2)
 	if len(parts) == 1 {
-		// No slash, it's a Docker Hub official image (e.g., "nginx")
 		return "docker.io"
 	}
-
 	firstPart := parts[0]
 	if strings.Contains(firstPart, ".") || strings.Contains(firstPart, ":") || firstPart == "localhost" {
 		return firstPart
 	}
-
-	// No registry specified (e.g., "library/nginx"), use Docker Hub
 	return "docker.io"
 }
 

--- a/container/docker_test.go
+++ b/container/docker_test.go
@@ -408,6 +408,24 @@ func TestExtractRegistry(t *testing.T) {
 			imageRef: "registry.example.com/myimage:v1.0.0",
 			expected: "registry.example.com",
 		},
+		// --- no-tag variants: the colon is part of the registry host:port,
+		// not a tag separator. The implementation must distinguish these
+		// from `nginx:latest` (where `:` is a tag separator).
+		{
+			name:     "localhost registry with port, no tag",
+			imageRef: "localhost:5000/myimage",
+			expected: "localhost:5000",
+		},
+		{
+			name:     "private registry with port, no tag",
+			imageRef: "registry.example.com:5000/myimage",
+			expected: "registry.example.com:5000",
+		},
+		{
+			name:     "localhost registry with port and digest, no tag",
+			imageRef: "localhost:5000/myimage@sha256:abc",
+			expected: "localhost:5000",
+		},
 	}
 
 	for _, tt := range tests {

--- a/container_deploy.go
+++ b/container_deploy.go
@@ -13,32 +13,22 @@ import (
 )
 
 // deployContainer performs the actual container deployment using rolling
-// update strategy. Returns the number of successfully deployed containers
-// and any error encountered.
-func (d *Dewy) deployContainer(ctx context.Context, res *registry.CurrentResponse) (int, error) {
+// update strategy. The runtime must be the same instance resolved by
+// resolveContainerState (and used for the image pull) so login state and
+// runtime configuration stay consistent across the per-tick deploy. Returns
+// the number of successfully deployed containers and any error encountered.
+func (d *Dewy) deployContainer(ctx context.Context, res *registry.CurrentResponse, runtime *container.Runtime) (int, error) {
 	if d.config.Container == nil {
 		return 0, fmt.Errorf("container config is nil")
 	}
-
-	// Create container runtime
-	runtime, err := container.New(d.config.Container.Runtime, d.logger.Slog(), d.config.Container.DrainTime)
-	if err != nil {
-		return 0, fmt.Errorf("failed to create container runtime: %w", err)
+	if runtime == nil {
+		return 0, fmt.Errorf("container runtime is nil")
 	}
 
 	// Extract image reference from artifact URL
 	// Format: img://registry/repo:tag
 	imageRef := strings.TrimPrefix(res.ArtifactURL, "img://")
-
-	// Determine app name from config or image
-	appName := d.config.Container.Name
-	if appName == "" {
-		parts := strings.Split(imageRef, "/")
-		if len(parts) > 0 {
-			lastPart := parts[len(parts)-1]
-			appName = strings.Split(lastPart, ":")[0]
-		}
-	}
+	appName := d.appName()
 
 	// Resolve port mappings (auto-detect ContainerPort==0 from image EXPOSE).
 	resolvedMappings, err := runtime.ResolvePortMappings(ctx, imageRef, d.config.Container.PortMappings)
@@ -130,22 +120,6 @@ func (d *Dewy) stopManagedContainers(ctx context.Context) error {
 	}
 
 	d.logger.Info("Stopping managed containers")
-
-	// Determine app name from config or registry
-	appName := d.config.Container.Name
-	if appName == "" {
-		registryURL := d.config.Registry
-		parts := strings.SplitN(registryURL, "://", 2)
-		if len(parts) == 2 {
-			pathParts := strings.Split(parts[1], "/")
-			if len(pathParts) > 0 {
-				lastPart := pathParts[len(pathParts)-1]
-				appName = strings.Split(lastPart, "?")[0]
-				appName = strings.Split(appName, ":")[0]
-			}
-		}
-	}
-
-	_, _, err := d.containerRuntime.StopManagedContainers(ctx, appName)
+	_, _, err := d.containerRuntime.StopManagedContainers(ctx, d.appName())
 	return err
 }

--- a/dewy.go
+++ b/dewy.go
@@ -303,7 +303,7 @@ func (d *Dewy) RunContainer() error {
 		return err
 	}
 
-	deployedCount, err := d.applyContainerDeployment(ctx, res)
+	deployedCount, err := d.applyContainerDeployment(ctx, res, st)
 	if err != nil {
 		return err
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -286,16 +286,7 @@ type containerState struct {
 func (d *Dewy) resolveContainerState(ctx context.Context, res *registry.CurrentResponse) (containerState, error) {
 	st := containerState{
 		imageRef: strings.TrimPrefix(res.ArtifactURL, "img://"),
-	}
-
-	st.appName = d.config.Container.Name
-	if st.appName == "" {
-		// Use repository name as app name.
-		parts := strings.Split(st.imageRef, "/")
-		if len(parts) > 0 {
-			lastPart := parts[len(parts)-1]
-			st.appName = strings.Split(lastPart, ":")[0]
-		}
+		appName:  d.appName(),
 	}
 
 	rt, err := container.New(d.config.Container.Runtime, d.logger.Slog(), d.config.Container.DrainTime)
@@ -346,9 +337,11 @@ func (d *Dewy) pullContainerImage(ctx context.Context, res *registry.CurrentResp
 
 // applyContainerDeployment runs the before-hook and the rolling deployment,
 // records telemetry, and returns the number of replicas successfully
-// deployed. The after-hook runs in promoteContainerAndReport so it only fires
-// once the deploy is considered final.
-func (d *Dewy) applyContainerDeployment(ctx context.Context, res *registry.CurrentResponse) (int, error) {
+// deployed. The runtime is the one resolveContainerState already created
+// (and pullContainerImage already used); deployContainer reuses it rather
+// than creating a duplicate. The after-hook runs in promoteContainerAndReport
+// so it only fires once the deploy is considered final.
+func (d *Dewy) applyContainerDeployment(ctx context.Context, res *registry.CurrentResponse, st containerState) (int, error) {
 	beforeResult, beforeErr := d.execHook(d.config.BeforeDeployHook)
 	if beforeResult != nil {
 		d.notifier.SendHookResult(ctx, "Before Deploy", beforeResult)
@@ -358,7 +351,7 @@ func (d *Dewy) applyContainerDeployment(ctx context.Context, res *registry.Curre
 	}
 
 	deployStart := time.Now()
-	deployedCount, err := d.deployContainer(ctx, res)
+	deployedCount, err := d.deployContainer(ctx, res, st.runtime)
 	if err != nil {
 		d.logger.Error("Container deployment failed",
 			slog.Int("deployed", deployedCount),

--- a/release.go
+++ b/release.go
@@ -3,6 +3,7 @@ package dewy
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -136,7 +137,7 @@ func (d *Dewy) startServer() error {
 }
 
 // keepReleases prunes old release directories under d.root, retaining the
-// keepReleases most recent by modification time.
+// keep most recent by modification time.
 func (d *Dewy) keepReleases() error {
 	dir := filepath.Join(d.root, releasesDir)
 	files, err := os.ReadDir(dir)
@@ -144,28 +145,55 @@ func (d *Dewy) keepReleases() error {
 		return err
 	}
 
-	sort.Slice(files, func(i, j int) bool {
-		fi, err := files[i].Info()
-		if err != nil {
-			return false
-		}
-		fj, err := files[j].Info()
-		if err != nil {
-			return true
-		}
-		return fi.ModTime().Unix() > fj.ModTime().Unix()
-	})
-
-	for i, f := range files {
-		if i < keepReleases {
-			continue
-		}
-		if err := os.RemoveAll(filepath.Join(dir, f.Name())); err != nil {
+	for _, name := range selectStaleReleases(files, keepReleases) {
+		if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
 			return err
 		}
 	}
-
 	return nil
+}
+
+// selectStaleReleases returns the names of release directories that should
+// be removed to retain at most `keep` entries by modification time (newest
+// first).
+//
+// Entries whose Info() errors (e.g. concurrent deletion, transient stat
+// failure) are excluded from both the keep set and the stale set: keeping
+// the in-memory comparator strictly ordered avoids the strict-weak-ordering
+// violation that the previous sort.Slice comparator would hit when Info()
+// returned an error mid-sort. Unstattable entries are simply left alone so
+// a transient FS hiccup does not remove the wrong directory.
+func selectStaleReleases(files []fs.DirEntry, keep int) []string {
+	type entry struct {
+		name    string
+		modTime time.Time
+	}
+	stat := make([]entry, 0, len(files))
+	for _, f := range files {
+		info, err := f.Info()
+		if err != nil {
+			continue
+		}
+		stat = append(stat, entry{name: f.Name(), modTime: info.ModTime()})
+	}
+
+	// Newest first; tie-break on name so equal mtimes yield a deterministic
+	// order even across runs.
+	sort.Slice(stat, func(i, j int) bool {
+		if !stat[i].modTime.Equal(stat[j].modTime) {
+			return stat[i].modTime.After(stat[j].modTime)
+		}
+		return stat[i].name < stat[j].name
+	})
+
+	if len(stat) <= keep {
+		return nil
+	}
+	stale := make([]string, 0, len(stat)-keep)
+	for _, e := range stat[keep:] {
+		stale = append(stale, e.name)
+	}
+	return stale
 }
 
 // cleanupOldImages removes old container images, keeping only the most recent ones.

--- a/release_test.go
+++ b/release_test.go
@@ -1,0 +1,110 @@
+package dewy
+
+import (
+	"errors"
+	"io/fs"
+	"slices"
+	"testing"
+	"time"
+)
+
+// fakeDirEntry implements os.DirEntry for retention tests, with controllable
+// Info() success / failure independent of the filesystem.
+type fakeDirEntry struct {
+	name    string
+	modTime time.Time
+	infoErr error
+}
+
+func (f fakeDirEntry) Name() string                { return f.name }
+func (f fakeDirEntry) IsDir() bool                 { return true }
+func (f fakeDirEntry) Type() fs.FileMode           { return fs.ModeDir }
+func (f fakeDirEntry) Info() (fs.FileInfo, error) {
+	if f.infoErr != nil {
+		return nil, f.infoErr
+	}
+	return fakeFileInfo{name: f.name, modTime: f.modTime}, nil
+}
+
+type fakeFileInfo struct {
+	name    string
+	modTime time.Time
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() fs.FileMode  { return fs.ModeDir }
+func (f fakeFileInfo) ModTime() time.Time { return f.modTime }
+func (f fakeFileInfo) IsDir() bool        { return true }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+// Sanity test: with all entries stattable, the oldest beyond `keep` are stale.
+func TestSelectStaleReleases_NewestKept(t *testing.T) {
+	now := time.Now()
+	files := []fs.DirEntry{
+		fakeDirEntry{name: "old1", modTime: now.Add(-3 * time.Hour)},
+		fakeDirEntry{name: "newest", modTime: now},
+		fakeDirEntry{name: "old2", modTime: now.Add(-2 * time.Hour)},
+		fakeDirEntry{name: "mid", modTime: now.Add(-1 * time.Hour)},
+	}
+	got := selectStaleReleases(files, 2)
+	slices.Sort(got)
+	want := []string{"old1", "old2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("stale = %v, want %v", got, want)
+	}
+}
+
+// The retained set must be the same regardless of input ordering. The old
+// sort.Slice comparator returned `false`/`true` on Info() errors, breaking
+// strict weak ordering and producing non-deterministic results when an
+// unstattable entry sat between stattable entries.
+func TestSelectStaleReleases_DeterministicWithInfoErrors(t *testing.T) {
+	now := time.Now()
+	infoErr := errors.New("stat: file vanished")
+
+	good := []fakeDirEntry{
+		{name: "a", modTime: now.Add(-3 * time.Hour)},
+		{name: "b", modTime: now.Add(-2 * time.Hour)},
+		{name: "c", modTime: now.Add(-1 * time.Hour)},
+		{name: "d", modTime: now},
+	}
+	bad := fakeDirEntry{name: "z-bad", infoErr: infoErr}
+
+	// Two permutations that the broken comparator would sort inconsistently.
+	perm1 := []fs.DirEntry{good[0], bad, good[1], good[2], good[3]}
+	perm2 := []fs.DirEntry{bad, good[3], good[2], good[1], good[0]}
+
+	stale1 := selectStaleReleases(perm1, 2)
+	stale2 := selectStaleReleases(perm2, 2)
+	slices.Sort(stale1)
+	slices.Sort(stale2)
+	if !slices.Equal(stale1, stale2) {
+		t.Errorf("non-deterministic: perm1=%v perm2=%v", stale1, stale2)
+	}
+
+	// The two newest stattable entries (c, d) must be retained.
+	for _, kept := range []string{"c", "d"} {
+		if slices.Contains(stale1, kept) {
+			t.Errorf("kept set should include %q, got stale=%v", kept, stale1)
+		}
+	}
+}
+
+// Unstattable entries must not push out stattable ones from the keep window.
+// (Old behavior could place an unstattable entry "newer" than real entries
+// and silently shorten the retention.)
+func TestSelectStaleReleases_UnstattableExcludedFromKeep(t *testing.T) {
+	now := time.Now()
+	files := []fs.DirEntry{
+		fakeDirEntry{name: "real-newest", modTime: now},
+		fakeDirEntry{name: "real-oldish", modTime: now.Add(-time.Hour)},
+		fakeDirEntry{name: "vanished", infoErr: errors.New("gone")},
+	}
+	stale := selectStaleReleases(files, 2)
+	for _, kept := range []string{"real-newest", "real-oldish"} {
+		if slices.Contains(stale, kept) {
+			t.Errorf("real entry %q should be kept (unstattable must not steal a slot), got stale=%v", kept, stale)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The 9-PR refactoring sequence (PR #425–#436) intentionally preserved several pre-existing bugs so each PR could be sold as "no behavior change". This PR addresses all six in one focused bug-fix pass. Each fix has a reproducing test written first; the test was confirmed to fail before the implementation landed.

The deferred items are tracked in https://github.com/linyows/dewy/pull/433#issuecomment-4364966102 and https://github.com/linyows/dewy/pull/434#issuecomment-4365027963.

## Group A — admin API + appName derivation (3 bugs)

The deploy path was deriving the app name (label `dewy.app`) from the image ref when `--name` was omitted, but the admin API read `Config.Container.Name` verbatim. So:

- `/api/containers` filtered by an empty label and returned 0 even when containers existed.
- `/api/status` returned an empty `name`.
- `handleGetContainers` nil-derefed when called during the startup window before the first `RunContainer` tick had set `d.containerRuntime`.

**Fix:**
- New `(d *Dewy) appName()` helper centralises the lookup (`app_name.go`).
- `lifecycle.go:resolveContainerState`, `container_deploy.go:deployContainer`, and `container_deploy.go:stopManagedContainers` now all call `appName()`.
- `admin_api.go` grows `containerListLabels()`; both handlers go through `appName()`.
- `handleGetContainers` nil-checks `d.containerRuntime` and returns 200 + empty list rather than panicking.

**Tests:** `app_name_test.go` (3 cases) and `admin_api_test.go` (4 cases).

## Group B — container runtime correctness (2 bugs)

### `extractRegistry` mishandled `localhost:5000/myimage`
The old logic treated the registry-port colon as a tag separator and fell back to `docker.io`. Replaced with the same lastSlash/lastColon comparison `imageRepositoryFromRef` uses — a `:` is a tag separator only when it appears after the last `/`.

**Tests:** 3 new no-tag cases added to `TestExtractRegistry` in `container/docker_test.go` (failed before fix, pass after).

### `deployContainer` created a duplicate `container.Runtime`
`resolveContainerState` already creates a runtime and stores it on `containerState` and `d.containerRuntime`. `deployContainer` ignored both and called `container.New` again, paying for an extra `exec.LookPath` and ending up with a separate `loggedInRegistries` map (so login state from the image pull was invisible to the deploy).

**Fix:** `deployContainer` now takes `runtime *container.Runtime` as a parameter; `applyContainerDeployment` threads `st.runtime` through. Type-system check is sufficient — no dedicated unit test (the runtime is opaque from outside the `container` package).

## Group C — `keepReleases` sort comparator (1 bug)

The `sort.Slice` comparator returned `false`/`true` asymmetrically on `DirEntry.Info()` errors, violating strict weak ordering and producing non-deterministic retention under concurrent deletion. The retention logic is now a pure helper `selectStaleReleases` that precomputes `(name, modTime)` for stattable entries, sorts with a modTime + name tie-break, and silently skips unstattable entries.

**Tests:** `release_test.go` includes determinism check across permutations and a "unstattable cannot steal a keep slot" case (failed before refactor, pass after).

## Test plan

- [x] `go test -race ./...` — all packages green
- [x] `go vet ./...` clean
- [x] Each new test was confirmed failing on the original code before the corresponding fix was applied (TDD).
- [ ] e2e if reviewer triggers `/e2e`

## Compatibility

All changes are internal. No CLI flags, config field names, cache keys, registry scheme strings, or release directory formats were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)