### PR TITLE
Apply go fix for Go 1.26 syntax modernizations

### DIFF
--- a/artifact/ghr_test.go
+++ b/artifact/ghr_test.go
@@ -83,11 +83,11 @@ func TestGHRDownload(t *testing.T) {
 					mock.GetReposReleasesByOwnerByRepo,
 					[]github.RepositoryRelease{
 						{
-							TagName: github.Ptr("v1.0.0"),
+							TagName: new("v1.0.0"),
 							Assets: []*github.ReleaseAsset{
 								{
-									ID:   github.Ptr(int64(12345)),
-									Name: github.Ptr("artifact.zip"),
+									ID:   new(int64(12345)),
+									Name: new("artifact.zip"),
 								},
 							},
 						},
@@ -108,11 +108,11 @@ func TestGHRDownload(t *testing.T) {
 					mock.GetReposReleasesByOwnerByRepo,
 					[]github.RepositoryRelease{
 						{
-							TagName: github.Ptr("v1.0.0"),
+							TagName: new("v1.0.0"),
 							Assets: []*github.ReleaseAsset{
 								{
-									ID:   github.Ptr(int64(12345)),
-									Name: github.Ptr("other-artifact.zip"),
+									ID:   new(int64(12345)),
+									Name: new("other-artifact.zip"),
 								},
 							},
 						},

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -71,8 +71,8 @@ func New(ctx context.Context, urlStr string, log *slog.Logger) (Cache, error) {
 }
 
 func schemeOf(urlStr string) string {
-	if i := strings.Index(urlStr, "://"); i >= 0 {
-		return urlStr[:i]
+	if before, _, ok := strings.Cut(urlStr, "://"); ok {
+		return before
 	}
 	u, err := url.Parse(urlStr)
 	if err != nil {

--- a/dewy.go
+++ b/dewy.go
@@ -310,4 +310,3 @@ func (d *Dewy) RunContainer() error {
 
 	return d.promoteContainerAndReport(ctx, res, deployedCount, st.imageRef)
 }
-

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -133,7 +133,6 @@ func (e *ErrorLimitingSender) OnDeploy(dir string) {
 	}
 }
 
-
 // SendHookResult sends hook result notification.
 // In quiet mode, only failed hook results are sent.
 func (e *ErrorLimitingSender) SendHookResult(ctx context.Context, hookType string, result *HookResult) {

--- a/registry/cached.go
+++ b/registry/cached.go
@@ -34,7 +34,7 @@ type cachedEntry struct {
 	FetchedAt time.Time        `json:"fetched_at"`
 	// LockedAt records when a peer began refreshing. Zero means no peer
 	// is currently refreshing.
-	LockedAt time.Time `json:"locked_at,omitempty"`
+	LockedAt time.Time `json:"locked_at"`
 	LockedBy string    `json:"locked_by,omitempty"`
 }
 

--- a/registry/cached_test.go
+++ b/registry/cached_test.go
@@ -167,7 +167,7 @@ func TestCachedFirstCallHitsUpstream(t *testing.T) {
 
 func TestCachedSubsequentCallsHitCache(t *testing.T) {
 	c, upstream, _ := newCachedForTest(t, time.Minute)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if _, err := c.Current(context.Background()); err != nil {
 			t.Fatalf("call %d: %v", i, err)
 		}

--- a/registry/calver.go
+++ b/registry/calver.go
@@ -134,7 +134,7 @@ func (f *CalVerFormat) Parse(version string) *CalVer {
 func (v *CalVer) Compare(other *CalVer) int {
 	maxLen := max(len(other.Segments), len(v.Segments))
 
-	for i := 0; i < maxLen; i++ {
+	for i := range maxLen {
 		var a, b int
 		if i < len(v.Segments) {
 			a = v.Segments[i]

--- a/registry/version.go
+++ b/registry/version.go
@@ -28,7 +28,7 @@ func comparePreRelease(a, b string) int {
 
 	maxLen := max(len(partsB), len(partsA))
 
-	for i := 0; i < maxLen; i++ {
+	for i := range maxLen {
 		if i >= len(partsA) {
 			return -1
 		}


### PR DESCRIPTION
## Summary

Run `go fix ./...` and `gofmt -w` to bring the codebase to current Go 1.26 idioms. All changes are mechanical and behaviour-preserving; each touched line was already correct, just verbose or carrying a silently-ineffective tag.

## Changes

| File | Change | Go version |
|---|---|---|
| `cache/cache.go` | `strings.Index + slicing` → `strings.Cut` | 1.18+ |
| `registry/cached_test.go`, `registry/calver.go`, `registry/version.go` | `for i := 0; i < N; i++` → `for i := range N` | 1.22+ (range over int) |
| `artifact/ghr_test.go` | `github.Ptr(v)` → built-in `new(v)` | 1.26 (`new(value)` form) |
| `registry/cached.go` | drop `,omitempty` from a `time.Time` field | dead tag — `time.Time` is a struct, not a zero-comparable scalar, so `encoding/json` never omits it |
| `dewy.go`, `notifier/notifier.go` | trailing blank lines removed by gofmt | pre-existing whitespace nits |

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` — all packages green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty

## Compatibility

Internal-only modernization. No public API surface, on-disk format, or wire format changed. The `omitempty` removal does change the JSON output for one private cache entry field by 1 line (`"locked_at": "0001-01-01T00:00:00Z"` instead of being omitted), but the field was already always serialized regardless because `omitempty` does not work on `time.Time`; old and new code reads either form correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)