### PR TITLE
Fix the documented default for --interval

### DIFF
--- a/docs/pages/reference.md
+++ b/docs/pages/reference.md
@@ -138,7 +138,7 @@ See [Versioning - Calendar Versioning](/versioning#calver) for full details.
 
 ### --interval (-i)
 
-Specifies the interval in seconds to check the registry. Default is 600 seconds (10 minutes).
+Specifies the interval in seconds to check the registry. Default is 10 seconds.
 
 ```bash
 dewy server --interval 300 -- /opt/app/current/app


### PR DESCRIPTION
`docs/pages/reference.md` documents `--interval` as defaulting to 600 seconds (10 minutes). The actual default is 10 seconds, and has been since 5f70503 (2018):

```go
// cli.go:236-237
if c.Interval < 0 {
    c.Interval = 10
}
```

The flag's own help text (`cli.go:41`) and the rest of the docs (`docs/pages/cache.md:238`, `docs/pages/deployment-workflow.md:13`) already say 10 seconds. `reference.md` is the only place claiming 600, and it has been wrong since the docs site landed in 4ed6414.
