### PR TITLE
Add opt-in exponential backoff for registry polling

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -39,6 +39,7 @@ type cli struct {
 	LogLevel         string   `long:"log-level" short:"l" arg:"(debug|info|warn|error)" description:"Set log level for output (default: error)"`
 	LogFormat        string   `long:"log-format" short:"f" arg:"(text|json)" description:"Set log format for output (default: text)"`
 	Interval         int      `long:"interval" arg:"seconds" short:"i" description:"Polling interval in seconds for checking registry updates (default: 10)"`
+	PollBackoffMax   int      `long:"poll-backoff-max" arg:"seconds" description:"Stretch the polling interval exponentially while checks keep failing, up to this many seconds (default: 0, disabled; 300 is a reasonable choice)"`
 	Ports            []string `long:"port" short:"p" description:"For server: TCP ports to listen on. For container: port mappings in format 'proxy' or 'proxy:container' (multiple flags supported)"`
 	Registry         string   `long:"registry" description:"Registry URL (e.g., ghr://owner/repo, s3://region/bucket/prefix, docker://registry/repo)"`
 	Cache            string   `long:"cache" short:"c" description:"Cache backend URL (e.g., file:///path, s3://region/bucket/prefix, gs://bucket/prefix). Defaults to local file."`
@@ -144,6 +145,7 @@ func (c *cli) buildHelp(names []string) []string {
 func (c *cli) showHelp() {
 	generalOpts := strings.Join(c.buildHelp([]string{
 		"Interval",
+		"PollBackoffMax",
 		"Registry",
 		"Cache",
 		"Slot",
@@ -269,6 +271,9 @@ func (c *cli) run() int {
 	conf.AdminPort = c.AdminPort
 	conf.Slot = c.Slot
 	conf.CalVer = c.CalVer
+	if c.PollBackoffMax > 0 {
+		conf.PollBackoffMax = time.Duration(c.PollBackoffMax) * time.Second
+	}
 
 	switch c.command {
 	case "server":

--- a/config.go
+++ b/config.go
@@ -93,6 +93,9 @@ type Config struct {
 	AfterDeployHook  string
 	Slot             string // Deployment slot for blue/green deployment (e.g., "blue", "green")
 	CalVer           string // CalVer format for version identification (e.g., "YYYY.0M.MICRO")
+	// PollBackoffMax bounds how far consecutive failures may stretch the
+	// polling interval. Zero keeps it fixed.
+	PollBackoffMax time.Duration
 	*Info
 }
 

--- a/dewy.go
+++ b/dewy.go
@@ -61,6 +61,7 @@ type Dewy struct {
 	containerRuntime *container.Runtime
 	cVer             string // Current deployed version (tag)
 	telemetry        *telemetry.Provider
+	backoff          *pollBackoff
 	sync.RWMutex
 }
 
@@ -100,6 +101,8 @@ func New(c Config, log *logging.Logger) (*Dewy, error) {
 		isServerRunning: false,
 		root:            wd,
 		logger:          log,
+		// Inert until Start knows the polling interval.
+		backoff: newPollBackoff(0, 0),
 	}, nil
 }
 
@@ -186,25 +189,50 @@ func (d *Dewy) Start(i int) {
 		}
 	}
 
-	d.job, err = scheduler.Every(i).Seconds().Run(func() {
-		var e error
-		if d.config.Command == CONTAINER {
-			e = d.RunContainer()
-		} else {
-			e = d.Run()
-		}
-		if e != nil {
-			d.logger.Error("Dewy run failure", slog.String("error", e.Error()))
-			d.notifier.SendError(context.Background(), e)
-		} else {
-			d.notifier.ResetErrorCount()
-		}
-	})
+	// A zero PollBackoffMax leaves the cadence fixed.
+	d.backoff = newPollBackoff(time.Duration(i)*time.Second, d.config.PollBackoffMax)
+	if d.config.PollBackoffMax > 0 {
+		d.logger.Info("Polling backoff enabled",
+			slog.Duration("max_delay", d.config.PollBackoffMax))
+	}
+
+	d.job, err = scheduler.Every(i).Seconds().Run(d.pollOnce)
 	if err != nil {
 		d.logger.Error("Scheduler failure", slog.String("error", err.Error()))
 	}
 
 	d.waitSigs(ctx)
+}
+
+// pollOnce is one tick of the polling loop. It is a named method rather than a
+// closure so tests can drive single ticks without the scheduler.
+func (d *Dewy) pollOnce() {
+	if d.backoff.skip() {
+		return
+	}
+
+	var e error
+	if d.config.Command == CONTAINER {
+		e = d.RunContainer()
+	} else {
+		e = d.Run()
+	}
+
+	if e != nil {
+		d.logger.Error("Dewy run failure", slog.String("error", e.Error()))
+		d.notifier.SendError(context.Background(), e)
+		if failures, until := d.backoff.failure(); !until.IsZero() {
+			d.logger.Warn("Polling backoff engaged",
+				slog.Int("consecutive_failures", failures),
+				slog.Time("next_attempt", until))
+		}
+	} else {
+		d.notifier.ResetErrorCount()
+		if cleared := d.backoff.success(); cleared > 0 {
+			d.logger.Info("Polling backoff cleared",
+				slog.Int("after_failures", cleared))
+		}
+	}
 }
 
 func (d *Dewy) waitSigs(ctx context.Context) {

--- a/dewy_test.go
+++ b/dewy_test.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/linyows/dewy/cache"
 	"github.com/linyows/dewy/container"
+	"github.com/linyows/dewy/internal/sysdeps/fake"
 	"github.com/linyows/dewy/logging"
 	"github.com/linyows/dewy/notifier"
 	"github.com/linyows/dewy/registry"
@@ -56,11 +58,24 @@ func TestNew(t *testing.T) {
 
 	opts := []cmp.Option{
 		cmp.AllowUnexported(Dewy{}, cache.File{}),
-		cmpopts.IgnoreFields(Dewy{}, "RWMutex", "logger", "tcpProxies", "proxyMutex", "containerRuntime"),
+		// backoff holds a func field that cmp cannot compare; it is asserted
+		// separately below.
+		cmpopts.IgnoreFields(Dewy{}, "RWMutex", "logger", "tcpProxies", "proxyMutex", "containerRuntime", "backoff"),
 		cmpopts.IgnoreFields(cache.File{}, "mutex", "logger"),
 	}
 	if diff := cmp.Diff(dewy, expect, opts...); diff != "" {
 		t.Error(diff)
+	}
+
+	// New leaves the backoff inert; Start installs one based on the interval.
+	if dewy.backoff == nil {
+		t.Fatal("New did not install a backoff")
+	}
+	if dewy.backoff.skip() {
+		t.Error("a freshly constructed Dewy is already backing off, want not")
+	}
+	if got := dewy.backoff.delayFor(5); got != 0 {
+		t.Errorf("delayFor(5) on a fresh Dewy = %v, want 0 (disabled until Start)", got)
 	}
 }
 
@@ -1350,5 +1365,187 @@ func TestMultiPortTCPProxy(t *testing.T) {
 	err = dewy.addProxyBackend("localhost", 9999, 19999)
 	if err == nil {
 		t.Error("Expected error when adding backend to non-existent proxy")
+	}
+}
+
+// newBackoffTestDewy returns a Dewy whose registry is driven by currentFunc and
+// whose backoff runs on a fake clock with exact (unjittered) windows.
+func newBackoffTestDewy(t *testing.T, clk *fake.Clock, currentFunc func(context.Context) (*registry.CurrentResponse, error)) (*Dewy, *mockNotify) {
+	t.Helper()
+
+	c := DefaultConfig()
+	c.Registry = "ghr://linyows/dewy"
+	d, err := New(c, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	notify := &mockNotify{messages: []string{}}
+	d.registry = &mockRegistry{currentFunc: currentFunc}
+	d.notifier = notify
+	d.backoff = newTestBackoff(10*time.Second, clk)
+
+	return d, notify
+}
+
+func TestPollOnceSkipsTicksWhileBackingOff(t *testing.T) {
+	var calls atomic.Int32
+	clk := testClock()
+	d, _ := newBackoffTestDewy(t, clk, func(ctx context.Context) (*registry.CurrentResponse, error) {
+		calls.Add(1)
+		return nil, errors.New("registry down")
+	})
+
+	// The first failure must not stretch the interval, so both ticks run.
+	d.pollOnce()
+	d.pollOnce()
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("registry calls after two failing ticks = %d, want 2", got)
+	}
+
+	// The second failure opened a 20s window: these ticks are no-ops.
+	d.pollOnce()
+	d.pollOnce()
+	if got := calls.Load(); got != 2 {
+		t.Errorf("registry calls during the backoff window = %d, want 2 (ticks must not reach the registry)", got)
+	}
+
+	clk.Advance(20 * time.Second)
+	d.pollOnce()
+	if got := calls.Load(); got != 3 {
+		t.Errorf("registry calls after the window elapsed = %d, want 3", got)
+	}
+}
+
+func TestPollOnceSkippedTickDoesNotNotify(t *testing.T) {
+	clk := testClock()
+	d, notify := newBackoffTestDewy(t, clk, func(ctx context.Context) (*registry.CurrentResponse, error) {
+		return nil, errors.New("registry down")
+	})
+
+	d.pollOnce()
+	d.pollOnce()
+	before := notify.errorCount
+
+	d.pollOnce()
+	d.pollOnce()
+
+	if notify.errorCount != before {
+		t.Errorf("notifier error count = %d after skipped ticks, want %d: a skipped tick did no work and must not report failure", notify.errorCount, before)
+	}
+}
+
+func TestPollOnceSuccessResumesNormalCadence(t *testing.T) {
+	var calls atomic.Int32
+	fail := true
+	clk := testClock()
+	d, _ := newBackoffTestDewy(t, clk, func(ctx context.Context) (*registry.CurrentResponse, error) {
+		calls.Add(1)
+		if fail {
+			return nil, errors.New("registry down")
+		}
+		// A slot mismatch is a successful tick that deploys nothing.
+		return &registry.CurrentResponse{ID: "id", Tag: "v1.0.0", Slot: ""}, nil
+	})
+	d.config.Slot = "blue"
+
+	d.pollOnce()
+	d.pollOnce()
+	if !d.backoff.skip() {
+		t.Fatal("backoff window did not open after two failures")
+	}
+
+	fail = false
+	clk.Advance(20 * time.Second)
+	d.pollOnce()
+
+	if got := d.backoff.failureCount(); got != 0 {
+		t.Errorf("failureCount() after a successful tick = %d, want 0", got)
+	}
+
+	// Back to the normal cadence: every subsequent tick reaches the registry.
+	before := calls.Load()
+	d.pollOnce()
+	d.pollOnce()
+	if got := calls.Load() - before; got != 2 {
+		t.Errorf("registry calls after recovery = %d, want 2", got)
+	}
+}
+
+// The artifact-not-found grace period is a "skip without error" and must not be
+// mistaken for a failure, or a slow CI upload would stretch the interval.
+func TestPollOnceGracePeriodDoesNotBackOff(t *testing.T) {
+	var calls atomic.Int32
+	clk := testClock()
+	d, _ := newBackoffTestDewy(t, clk, func(ctx context.Context) (*registry.CurrentResponse, error) {
+		calls.Add(1)
+		now := time.Now()
+		return nil, &registry.ArtifactNotFoundError{
+			Message:     "artifact not found",
+			ReleaseTime: &now,
+		}
+	})
+
+	for i := 0; i < 5; i++ {
+		d.pollOnce()
+	}
+
+	if got := calls.Load(); got != 5 {
+		t.Fatalf("registry calls = %d, want 5: every tick must still run", got)
+	}
+
+	if got := d.backoff.failureCount(); got != 0 {
+		t.Errorf("failureCount() during the grace period = %d, want 0", got)
+	}
+	if d.backoff.skip() {
+		t.Error("skip() during the grace period = true, want false")
+	}
+}
+
+// Without --poll-backoff-max, ticks must keep reaching the registry no matter
+// how long it has been failing: the default is the cadence dewy always had.
+func TestPollOnceDefaultConfigNeverSkips(t *testing.T) {
+	var calls atomic.Int32
+	clk := testClock()
+	d, _ := newBackoffTestDewy(t, clk, func(ctx context.Context) (*registry.CurrentResponse, error) {
+		calls.Add(1)
+		return nil, errors.New("registry down")
+	})
+
+	// Build the backoff exactly as Start does from an untouched config.
+	if d.config.PollBackoffMax != 0 {
+		t.Fatalf("DefaultConfig().PollBackoffMax = %v, want 0: the backoff must be opt-in", d.config.PollBackoffMax)
+	}
+	d.backoff = newPollBackoff(10*time.Second, d.config.PollBackoffMax)
+	d.backoff.clock = clk
+
+	for i := 0; i < 10; i++ {
+		d.pollOnce()
+	}
+
+	if got := calls.Load(); got != 10 {
+		t.Errorf("registry calls over 10 failing ticks = %d, want 10 (no tick may be skipped by default)", got)
+	}
+}
+
+// Opting in changes the cadence; this is the counterpart to the test above.
+func TestPollOnceOptInSkipsTicks(t *testing.T) {
+	var calls atomic.Int32
+	clk := testClock()
+	d, _ := newBackoffTestDewy(t, clk, func(ctx context.Context) (*registry.CurrentResponse, error) {
+		calls.Add(1)
+		return nil, errors.New("registry down")
+	})
+	d.config.PollBackoffMax = 5 * time.Minute
+	d.backoff = newPollBackoff(10*time.Second, d.config.PollBackoffMax)
+	d.backoff.clock = clk
+	d.backoff.jitter = identityJitter
+
+	for i := 0; i < 10; i++ {
+		d.pollOnce()
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("registry calls over 10 failing ticks = %d, want 2 (the window opens after the second failure)", got)
 	}
 }

--- a/docs/pages/reference.md
+++ b/docs/pages/reference.md
@@ -144,6 +144,32 @@ Specifies the interval in seconds to check the registry. Default is 600 seconds 
 dewy server --interval 300 -- /opt/app/current/app
 ```
 
+### --poll-backoff-max
+
+Stretches the polling interval exponentially while checks keep failing, so that
+a registry outage is not met with an unchanged request rate. The value is the
+upper bound in seconds. Default is `0`, which disables the backoff and keeps the
+fixed interval Dewy has always used.
+
+```bash
+dewy server --interval 10 --poll-backoff-max 300 -- /opt/app/current/app
+```
+
+A single failure changes nothing. From the second consecutive failure the wait
+doubles each time (`interval`, `2x`, `4x`, ...), jittered, and never grows past
+the bound given here. The first successful check restores the configured
+interval immediately.
+
+With `--interval 10 --poll-backoff-max 300`, a registry that stays down is
+polled at most 10s, 20s, 40s, 80s and 160s apart, then at most 300s apart,
+instead of every 10s. Jitter only ever shortens those waits, and each one lands
+on a multiple of `--interval` because the scheduler keeps firing at that
+cadence. The trade-off is that a release landing right after recovery can go
+unnoticed for up to the bound.
+
+A bound shorter than `--interval` has no effect, since a delay is never shorter
+than one interval.
+
 ### --verbose (-v)
 
 Enables verbose log output. Useful for debugging and troubleshooting.

--- a/poll_backoff.go
+++ b/poll_backoff.go
@@ -1,0 +1,132 @@
+package dewy
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/linyows/dewy/internal/sysdeps"
+)
+
+// pollBackoff stretches the effective polling interval after consecutive
+// failures. The scheduler keeps firing at the configured interval; this only
+// decides whether a tick does any work.
+//
+// The first failure never opens a window: one failed tick is more often a blip
+// than an outage, and delaying recovery for it costs more than it saves.
+type pollBackoff struct {
+	mu       sync.Mutex
+	base     time.Duration
+	maxDelay time.Duration
+	clock    sysdeps.Clock
+	// jitter spreads the delay above base; failure applies it. Tests replace
+	// it to make windows exact.
+	jitter   func(time.Duration) time.Duration
+	failures int
+	until    time.Time
+}
+
+// newPollBackoff grows delays from base, bounded by maxDelay. A maxDelay of
+// zero -- the default, meaning no --poll-backoff-max -- is inert and never
+// skips a tick; so is a zero base. maxDelay is raised to base so a delay can
+// never come out shorter than one interval.
+func newPollBackoff(base, maxDelay time.Duration) *pollBackoff {
+	if maxDelay > 0 && base > maxDelay {
+		maxDelay = base
+	}
+	return &pollBackoff{
+		base:     base,
+		maxDelay: maxDelay,
+		clock:    sysdeps.RealClock(),
+		jitter:   equalJitter,
+	}
+}
+
+// equalJitter returns a duration in [d/2, d). Applied only above base, so the
+// total stays over one interval while still spreading instances that failed
+// together.
+func equalJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	half := d / 2
+	if half <= 0 {
+		return d
+	}
+	return half + time.Duration(rand.Int63n(int64(half))) //nolint:gosec // G404: jitter needs no cryptographic randomness
+}
+
+// skip reports whether a backoff window is still open.
+func (b *pollBackoff) skip() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.until.IsZero() {
+		return false
+	}
+	return b.clock.Now().Before(b.until)
+}
+
+// success clears the failure streak and returns the length it cleared.
+func (b *pollBackoff) success() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	cleared := b.failures
+	b.failures = 0
+	b.until = time.Time{}
+	return cleared
+}
+
+// failure records a failed tick and returns the new streak along with the time
+// polling resumes, or the zero time when no window opened.
+func (b *pollBackoff) failure() (failures int, until time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.failures++
+	d := b.delayForLocked(b.failures)
+	if d <= b.base {
+		b.until = time.Time{}
+		return b.failures, time.Time{}
+	}
+
+	b.until = b.clock.Now().Add(b.base + b.jitter(d-b.base))
+	return b.failures, b.until
+}
+
+// failureCount returns the consecutive-failure streak.
+func (b *pollBackoff) failureCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.failures
+}
+
+// delayFor returns the delay for n consecutive failures, before jitter.
+func (b *pollBackoff) delayFor(n int) time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.delayForLocked(n)
+}
+
+// delayForLocked doubles in a loop rather than shifting by n, so a long streak
+// cannot overflow the duration.
+func (b *pollBackoff) delayForLocked(n int) time.Duration {
+	if b.base <= 0 || b.maxDelay <= 0 {
+		return 0
+	}
+	if n <= 1 {
+		return b.base
+	}
+
+	d := b.base
+	for i := 1; i < n; i++ {
+		d *= 2
+		if d >= b.maxDelay {
+			return b.maxDelay
+		}
+	}
+	return d
+}

--- a/poll_backoff_test.go
+++ b/poll_backoff_test.go
@@ -1,0 +1,231 @@
+package dewy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/linyows/dewy/internal/sysdeps/fake"
+)
+
+// identityJitter makes delays exact so that window boundaries can be asserted.
+func identityJitter(d time.Duration) time.Duration { return d }
+
+func testClock() *fake.Clock {
+	return fake.NewClock(time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC))
+}
+
+// testBackoffMax is the bound an operator would pass via --poll-backoff-max.
+const testBackoffMax = 5 * time.Minute
+
+func newTestBackoff(base time.Duration, clk *fake.Clock) *pollBackoff {
+	b := newPollBackoff(base, testBackoffMax)
+	b.clock = clk
+	b.jitter = identityJitter
+	return b
+}
+
+func TestPollBackoffRunsBeforeAnyFailure(t *testing.T) {
+	b := newTestBackoff(10*time.Second, testClock())
+
+	if b.skip() {
+		t.Error("skip() on a fresh backoff = true, want false: the first tick must always run")
+	}
+}
+
+func TestPollBackoffFirstFailureDoesNotStretch(t *testing.T) {
+	b := newTestBackoff(10*time.Second, testClock())
+
+	if failures, until := b.failure(); !until.IsZero() {
+		t.Errorf("failure() #1 (streak %d) opened a window until %v, want none", failures, until)
+	}
+	if b.skip() {
+		t.Error("skip() after one failure = true, want false: a single blip must not delay recovery")
+	}
+}
+
+func TestPollBackoffSecondFailureOpensWindow(t *testing.T) {
+	clk := testClock()
+	b := newTestBackoff(10*time.Second, clk)
+
+	b.failure()
+	b.failure()
+
+	if !b.skip() {
+		t.Fatal("skip() after two failures = false, want true")
+	}
+
+	// One second short of the window: still skipping.
+	clk.Advance(19 * time.Second)
+	if !b.skip() {
+		t.Error("skip() at +19s = false, want true: the 20s window is not over yet")
+	}
+
+	clk.Advance(1 * time.Second)
+	if b.skip() {
+		t.Error("skip() at +20s = true, want false: the window has elapsed")
+	}
+}
+
+func TestPollBackoffThirdFailureDoubles(t *testing.T) {
+	clk := testClock()
+	b := newTestBackoff(10*time.Second, clk)
+
+	b.failure()
+	b.failure()
+	b.failure()
+
+	clk.Advance(39 * time.Second)
+	if !b.skip() {
+		t.Error("skip() at +39s = false, want true: the third failure delays for 40s")
+	}
+	clk.Advance(1 * time.Second)
+	if b.skip() {
+		t.Error("skip() at +40s = true, want false")
+	}
+}
+
+func TestPollBackoffSuccessClearsWindow(t *testing.T) {
+	b := newTestBackoff(10*time.Second, testClock())
+
+	b.failure()
+	b.failure()
+	b.failure()
+	if !b.skip() {
+		t.Fatal("skip() after three failures = false, want true")
+	}
+
+	b.success()
+
+	if b.skip() {
+		t.Error("skip() after success() = true, want false: cadence must resume immediately")
+	}
+	if got := b.failureCount(); got != 0 {
+		t.Errorf("failureCount() after success() = %d, want 0", got)
+	}
+}
+
+func TestPollBackoffDelayGrowthAndCap(t *testing.T) {
+	b := newTestBackoff(10*time.Second, testClock())
+
+	tests := []struct {
+		failures int
+		want     time.Duration
+	}{
+		{1, 10 * time.Second},
+		{2, 20 * time.Second},
+		{3, 40 * time.Second},
+		{4, 80 * time.Second},
+		{5, 160 * time.Second},
+		{6, testBackoffMax},
+		{20, testBackoffMax},
+		{1000, testBackoffMax},
+	}
+
+	for _, tt := range tests {
+		if got := b.delayFor(tt.failures); got != tt.want {
+			t.Errorf("delayFor(%d) = %v, want %v", tt.failures, got, tt.want)
+		}
+	}
+}
+
+// Without --poll-backoff-max the backoff must never skip a tick, so existing
+// deployments keep the cadence they have always had.
+func TestPollBackoffDisabledByDefault(t *testing.T) {
+	clk := testClock()
+	b := newPollBackoff(10*time.Second, 0) // as if --poll-backoff-max were never passed
+	b.clock = clk
+	b.jitter = identityJitter
+
+	for i := 0; i < 10; i++ {
+		if failures, until := b.failure(); !until.IsZero() {
+			t.Fatalf("failure() #%d opened a window until %v, want none when no max is set", failures, until)
+		}
+		if b.skip() {
+			t.Fatalf("skip() after %d failures = true, want false when no max is set", i+1)
+		}
+	}
+
+	if got := b.delayFor(5); got != 0 {
+		t.Errorf("delayFor(5) with no max = %v, want 0", got)
+	}
+
+	// Advancing time must not resurrect a window either.
+	clk.Advance(1 * time.Hour)
+	if b.skip() {
+		t.Error("skip() after an hour = true, want false")
+	}
+}
+
+func TestPollBackoffDisabledWhenBaseIsZero(t *testing.T) {
+	b := newTestBackoff(0, testClock())
+
+	for i := 0; i < 5; i++ {
+		b.failure()
+	}
+
+	if b.skip() {
+		t.Error("skip() with a zero base = true, want false: the backoff must be inert before Start installs an interval")
+	}
+}
+
+// An operator already polling more slowly than the cap gets no backoff, rather
+// than a delay shorter than their own interval.
+func TestPollBackoffIntervalLongerThanCap(t *testing.T) {
+	base := 10 * time.Minute // longer than testBackoffMax
+	b := newTestBackoff(base, testClock())
+
+	if got := b.delayFor(5); got != base {
+		t.Errorf("delayFor(5) with base %v = %v, want %v", base, got, base)
+	}
+
+	b.failure()
+	b.failure()
+	if b.skip() {
+		t.Error("skip() = true, want false: no window should open when the cap cannot exceed base")
+	}
+}
+
+// The jittered window must never fall below one polling interval, or dewy
+// would poll faster while backing off.
+func TestPollBackoffEqualJitterStaysAboveBase(t *testing.T) {
+	base := 10 * time.Second
+
+	for i := 0; i < 200; i++ {
+		clk := testClock()
+		start := clk.Now()
+		b := newPollBackoff(base, testBackoffMax) // keeps the real equalJitter
+		b.clock = clk
+
+		b.failure()
+		_, until := b.failure()
+
+		got := until.Sub(start)
+		// delayFor(2) is 20s, so the window is base + jitter(10s) = [15s, 20s).
+		if got < 15*time.Second || got >= 20*time.Second {
+			t.Fatalf("window = %v, want within [15s, 20s)", got)
+		}
+		if got <= base {
+			t.Fatalf("window = %v, want longer than the base interval %v", got, base)
+		}
+	}
+}
+
+func TestEqualJitterBounds(t *testing.T) {
+	if got := equalJitter(0); got != 0 {
+		t.Errorf("equalJitter(0) = %v, want 0", got)
+	}
+	if got := equalJitter(-time.Second); got != 0 {
+		t.Errorf("equalJitter(-1s) = %v, want 0", got)
+	}
+	if got := equalJitter(time.Nanosecond); got != time.Nanosecond {
+		t.Errorf("equalJitter(1ns) = %v, want 1ns: a duration too small to halve is returned as-is", got)
+	}
+
+	for i := 0; i < 200; i++ {
+		d := 40 * time.Second
+		got := equalJitter(d)
+		if got < d/2 || got >= d {
+			t.Fatalf("equalJitter(%v) = %v, want within [%v, %v)", d, got, d/2, d)
+		}
+	}
+}


### PR DESCRIPTION
The polling scheduler fires at a fixed interval, so a registry that is down is
met with an unchanged request rate for as long as the outage lasts. At the
default `--interval 10` that is 360 attempts an hour per instance, every one of
them failing.

`--poll-backoff-max <seconds>` bounds that. While checks keep failing the
effective interval doubles from the configured interval, jittered, up to the
given bound; the first successful check restores the normal cadence
immediately.

```bash
dewy server --interval 10 --poll-backoff-max 300 -- /opt/app/current/app

# a registry that stays down is then polled at most 10s, 20s, 40s, 80s and 160s
# apart, and at most 300s apart from there on, instead of every 10s
```

The flag defaults to `0`, which disables the backoff entirely, so no existing
deployment changes behavior without opting in. `TestPollOnceDefaultConfigNeverSkips`
pins that: ten consecutive failing ticks still make ten registry calls.

Two decisions worth flagging:

- The first failure never stretches the interval. One failed tick is more often
  a blip than an outage, and delaying recovery for it costs more than it saves,
  so only the second consecutive failure opens a window.
- Jitter is applied to the portion of the delay above the interval rather than
  to the whole delay, so a jittered wait can never come out shorter than one
  polling interval. A bound shorter than `--interval` is therefore inert.

The scheduler itself is untouched: it keeps firing at the configured interval
and `pollOnce` returns immediately while a window is open. `carlescere/scheduler`
offers no way to vary a job's period, and replacing it looked like a much larger
change than this warrants.

`poll_backoff_test.go` drives the window boundaries off a fake clock
(`internal/sysdeps/fake`), so no test sleeps. `dewy_test.go` covers the wiring,
including that the artifact-not-found grace period is not mistaken for a
failure.
