### PR TITLE
Fix the docs build by pinning react and react-dom to the same version

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -13,8 +13,8 @@
         "next": "^16.2.10",
         "next-sitemap": "^4.2.3",
         "prismjs": "^1.30.0",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.7",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
       },
       "devDependencies": {
         "@types/node": "latest",
@@ -445,9 +445,9 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
-    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,8 +16,8 @@
     "next": "^16.2.10",
     "next-sitemap": "^4.2.3",
     "prismjs": "^1.30.0",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.7"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@types/node": "latest",


### PR DESCRIPTION
The docs site has not deployed since 2026-07-19. Every `Github Pages` run since then fails in `Build and Export`:

```
unhandledRejection Error: Incompatible React versions: The "react" and
"react-dom" packages must have the exact same version.
error: script "build" exited with code 1
```

## Cause

Dependabot bumped `react` and `react-dom` in separate PRs, so their caret ranges drifted apart:

- 9863e12 took `react-dom` from `^19.2.5` to `^19.2.7`
- 5e60895 took `react` from `^19.2.5` to `^19.2.6`

`bun.lock` then resolved `react@19.2.6` against `react-dom@19.2.7`, and Next.js requires the two to be exactly equal. Earlier bumps happened to land on the same version, which is why this only started failing in July.

## Fix

Caret ranges cannot express "exactly equal to the other package". Raising `react` to `^19.2.7` does not help either: it resolves to the newest 19.2.x, which is 19.2.8, while `react-dom` stays at whatever its own range picked. I tried that first and got the same mismatch one version along.

Both are pinned to `19.2.8` instead, which is what the manifest should have said in the first place. The lockfile diff is four lines.

Dependabot was narrowed to Go modules at the repository root in #473, so nothing will split the pair again on its own.

## Verification

`bun run build` succeeds locally. The built `out/ja/reference.html` carries the `--max-backoff-interval` section and no longer contains `レジストリー`, so the Japanese documentation from #482 reaches the site once this deploys.

The open Dependabot PRs against `docs/` (#465 through #469) predate #473 and are unaffected by this change.
