### PR TITLE
Define the container label keys as package constants

### DIFF
--- a/admin_api.go
+++ b/admin_api.go
@@ -14,18 +14,16 @@ import (
 
 // startAdminAPI starts the admin API server on TCP localhost.
 func (d *Dewy) startAdminAPI(ctx context.Context) error {
-	// Default admin port is 17539 (DEWY: D=4, E=5, W=23, Y=25 -> 4+5+2+3+2+5=21, but 17539 is more unique)
 	adminPort := d.config.AdminPort
 	if adminPort == 0 {
-		adminPort = 17539
+		adminPort = defaultAdminPort
 	}
 
 	// Try to bind to the port, increment if already in use
 	var listener net.Listener
 	var err error
-	maxAttempts := 10
 
-	for i := range maxAttempts {
+	for i := range adminPortMaxAttempts {
 		currentPort := adminPort + i
 		addr := fmt.Sprintf("localhost:%d", currentPort)
 		listener, err = net.Listen("tcp", addr)
@@ -42,7 +40,7 @@ func (d *Dewy) startAdminAPI(ctx context.Context) error {
 	}
 
 	if listener == nil {
-		return fmt.Errorf("failed to bind admin API after %d attempts: %w", maxAttempts, err)
+		return fmt.Errorf("failed to bind admin API after %d attempts: %w", adminPortMaxAttempts, err)
 	}
 
 	// Create HTTP mux for admin API

--- a/admin_api.go
+++ b/admin_api.go
@@ -103,8 +103,8 @@ func (d *Dewy) stopAdminAPI(ctx context.Context) error {
 // derived repository name).
 func (d *Dewy) containerListLabels() map[string]string {
 	return map[string]string{
-		"dewy.managed": "true",
-		"dewy.app":     d.appName(),
+		container.LabelManaged: container.LabelManagedValue,
+		container.LabelApp:     d.appName(),
 	}
 }
 

--- a/cli.go
+++ b/cli.go
@@ -443,8 +443,8 @@ func (c *cli) configureContainerCommand(conf *Config) error {
 		}
 	}
 
-	// ProxyIdleTimeout: -1 means not specified (use default 5min), 0 means disabled, >0 means custom
-	proxyIdleTimeout := 5 * time.Minute
+	// ProxyIdleTimeout: -1 means not specified (use the default), 0 means disabled, >0 means custom
+	proxyIdleTimeout := defaultProxyIdleTimeout
 	if c.ProxyIdleTimeout == 0 {
 		proxyIdleTimeout = 0 // Explicitly disabled
 	} else if c.ProxyIdleTimeout > 0 {
@@ -702,14 +702,13 @@ https://github.com/linyows/dewy
 
 // runContainerList runs the "dewy container list" command.
 func (c *cli) runContainerList() int {
-	// Default admin port
 	adminPort := c.AdminPort
 	if adminPort == 0 {
-		adminPort = 17539
+		adminPort = defaultAdminPort
 	}
 
-	// Try to connect to admin API, scanning through possible ports
-	maxAttempts := 10
+	// Try to connect to admin API, scanning through the same range of ports
+	// that startAdminAPI increments over.
 	client := &http.Client{
 		Timeout: 2 * time.Second,
 	}
@@ -718,7 +717,7 @@ func (c *cli) runContainerList() int {
 	var err error
 	var successPort int
 
-	for i := range maxAttempts {
+	for i := range adminPortMaxAttempts {
 		currentPort := adminPort + i
 		url := fmt.Sprintf("http://localhost:%d/api/containers", currentPort)
 
@@ -732,7 +731,7 @@ func (c *cli) runContainerList() int {
 
 	if resp == nil {
 		fmt.Fprintf(c.env.Err, "Error: no running dewy instances found (tried ports %d-%d)\n",
-			adminPort, adminPort+maxAttempts-1)
+			adminPort, adminPort+adminPortMaxAttempts-1)
 		return ExitErr
 	}
 	defer resp.Body.Close()

--- a/container/container.go
+++ b/container/container.go
@@ -8,6 +8,33 @@ import (
 	"time"
 )
 
+// Labels dewy attaches to every container it deploys. Discovery (the deploy
+// path, the reaper, the admin API, the metrics observer) filters on these, so
+// they are part of the package's contract rather than an implementation
+// detail: callers outside this package must reference these constants instead
+// of repeating the strings.
+const (
+	// LabelPrefix is the label namespace dewy reserves for itself. Users
+	// cannot set labels under it because doing so would interfere with
+	// container discovery.
+	LabelPrefix = "dewy."
+
+	// LabelManaged marks a container as deployed by dewy. Its value is
+	// always LabelManagedValue.
+	LabelManaged = LabelPrefix + "managed"
+	// LabelApp scopes a container to one dewy instance's application name.
+	LabelApp = LabelPrefix + "app"
+	// LabelVersion records the deployed tag.
+	LabelVersion = LabelPrefix + "version"
+	// LabelReplica records the 0-based replica index.
+	LabelReplica = LabelPrefix + "replica"
+	// LabelDeployedAt records the deploy time in RFC3339.
+	LabelDeployedAt = LabelPrefix + "deployed_at"
+
+	// LabelManagedValue is the only value LabelManaged ever takes.
+	LabelManagedValue = "true"
+)
+
 // supportedRuntimes is the allowlist of container runtime commands.
 var supportedRuntimes = map[string]bool{
 	"docker": true,

--- a/container/deploy.go
+++ b/container/deploy.go
@@ -27,8 +27,8 @@ func (r *Runtime) Deploy(ctx context.Context, opts RollingDeployOptions, updater
 
 	// Find existing containers
 	existingContainers, err := r.FindContainersByLabel(ctx, map[string]string{
-		"dewy.managed": "true",
-		"dewy.app":     opts.AppName,
+		LabelManaged: LabelManagedValue,
+		LabelApp:     opts.AppName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find existing containers: %w", err)
@@ -141,11 +141,11 @@ func (r *Runtime) startAndCheck(ctx context.Context, opts RollingDeployOptions, 
 		ReplicaIndex: replicaIndex,
 		Ports:        ports,
 		Labels: map[string]string{
-			"dewy.managed":     "true",
-			"dewy.app":         opts.AppName,
-			"dewy.deployed_at": time.Now().Format(time.RFC3339),
-			"dewy.replica":     strconv.Itoa(replicaIndex),
-			"dewy.version":     opts.Version,
+			LabelManaged:    LabelManagedValue,
+			LabelApp:        opts.AppName,
+			LabelDeployedAt: time.Now().Format(time.RFC3339),
+			LabelReplica:    strconv.Itoa(replicaIndex),
+			LabelVersion:    opts.Version,
 		},
 		Detach:    true,
 		Command:   opts.Command,
@@ -237,13 +237,14 @@ func (r *Runtime) rollback(ctx context.Context, results []DeployResult, updater 
 	}
 }
 
-// StopManagedContainers stops and removes all containers with dewy.managed=true and matching app name.
+// StopManagedContainers stops and removes all containers labeled as managed
+// by dewy and matching app name.
 func (r *Runtime) StopManagedContainers(ctx context.Context, appName string) (int, int, error) {
 	labels := map[string]string{
-		"dewy.managed": "true",
+		LabelManaged: LabelManagedValue,
 	}
 	if appName != "" {
-		labels["dewy.app"] = appName
+		labels[LabelApp] = appName
 	}
 
 	containerIDs, err := r.FindContainersByLabel(ctx, labels)

--- a/container/inspect.go
+++ b/container/inspect.go
@@ -49,8 +49,8 @@ type Status struct {
 	Restarts   int
 	ExitCode   int
 	OOMKilled  bool
-	Replica    string // dewy.replica label, "" for pre-upgrade containers
-	Version    string // dewy.version label, "" for pre-upgrade containers
+	Replica    string // LabelReplica value, "" for pre-upgrade containers
+	Version    string // LabelVersion value, "" for pre-upgrade containers
 	StartedAt  time.Time
 	FinishedAt time.Time
 }
@@ -145,8 +145,8 @@ func (r *Runtime) RemoveExited(ctx context.Context, appName string) (int, error)
 	// shared runtime, which is a destructive cross-app action.
 	args := []string{"ps", "-aq",
 		"--filter", "status=exited",
-		"--filter", "label=dewy.managed=true",
-		"--filter", fmt.Sprintf("label=dewy.app=%s", appName)}
+		"--filter", "label=" + LabelManaged + "=" + LabelManagedValue,
+		"--filter", fmt.Sprintf("label=%s=%s", LabelApp, appName)}
 
 	output, err := r.execCommandOutput(ctx, args...)
 	if err != nil {
@@ -180,9 +180,9 @@ func (r *Runtime) RemoveExited(ctx context.Context, appName string) (int, error)
 // backs the whole result so the cost is one exec per call regardless of replica
 // count. An empty appName lists all managed containers.
 func (r *Runtime) InspectManaged(ctx context.Context, appName string) ([]*Status, error) {
-	labels := map[string]string{"dewy.managed": "true"}
+	labels := map[string]string{LabelManaged: LabelManagedValue}
 	if appName != "" {
-		labels["dewy.app"] = appName
+		labels[LabelApp] = appName
 	}
 
 	ids, err := r.findContainerIDs(ctx, labels, true)
@@ -230,8 +230,8 @@ func (r *Runtime) toStatus(in *inspection) *Status {
 		Restarts:   in.RestartCount,
 		ExitCode:   in.State.ExitCode,
 		OOMKilled:  in.State.OOMKilled,
-		Replica:    in.Config.Labels["dewy.replica"],
-		Version:    in.Config.Labels["dewy.version"],
+		Replica:    in.Config.Labels[LabelReplica],
+		Version:    in.Config.Labels[LabelVersion],
 		StartedAt:  parseTime(in.State.StartedAt),
 		FinishedAt: parseTime(in.State.FinishedAt),
 	}
@@ -280,7 +280,7 @@ func (r *Runtime) GetMappedPort(ctx context.Context, containerID string, contain
 func (r *Runtime) GetRunningContainerWithImage(ctx context.Context, imageRef, appName string) (string, error) {
 	output, err := r.execCommandOutput(ctx, "ps",
 		"--filter", fmt.Sprintf("ancestor=%s", imageRef),
-		"--filter", fmt.Sprintf("label=dewy.app=%s", appName),
+		"--filter", fmt.Sprintf("label=%s=%s", LabelApp, appName),
 		"--filter", "status=running",
 		"--format", "{{.ID}}")
 
@@ -329,7 +329,7 @@ func (r *Runtime) GetContainerInfo(ctx context.Context, containerID string, cont
 	}
 
 	deployedAt := startedAt
-	if deployedAtStr, ok := inspect.Config.Labels["dewy.deployed_at"]; ok {
+	if deployedAtStr, ok := inspect.Config.Labels[LabelDeployedAt]; ok {
 		if t, err := time.Parse(time.RFC3339, deployedAtStr); err == nil {
 			deployedAt = t
 		}

--- a/container/runtime.go
+++ b/container/runtime.go
@@ -34,7 +34,7 @@ func WithCommandRunner(r sysdeps.CommandRunner) Option {
 
 // forbiddenLongOptions are long-form flags that conflict with Dewy management
 // or pose security risks. --label-file is included because its file contents
-// would bypass the reservedLabelPrefix check.
+// would bypass the LabelPrefix check.
 var forbiddenLongOptions = []string{
 	"--detach",
 	"--interactive",
@@ -62,11 +62,6 @@ var forbiddenLongOptions = []string{
 // short (e.g., -qd) are not caught, but extra args are user-supplied so that
 // blind spot does not cross a privilege boundary.
 var forbiddenShortFlagChars = []byte{'d', 'i', 't', 'p'}
-
-// reservedLabelPrefix is the label namespace Dewy uses to track managed
-// containers. Users cannot set labels under this prefix because doing so
-// would interfere with container discovery (FindContainersByLabel).
-const reservedLabelPrefix = "dewy."
 
 // newCLIRuntime creates a new Runtime with the specified command name.
 func newCLIRuntime(cmd string, logger *slog.Logger, drainTime time.Duration, opts ...Option) (*Runtime, error) {
@@ -141,8 +136,8 @@ func validateExtraArgs(args []string) error {
 			return fmt.Errorf("option -%c conflicts with Dewy management and cannot be used", c)
 		}
 
-		if value, ok := extractLabelValue(args, i); ok && strings.HasPrefix(value, reservedLabelPrefix) {
-			return fmt.Errorf("label %q uses reserved prefix %q and cannot be used", value, reservedLabelPrefix)
+		if value, ok := extractLabelValue(args, i); ok && strings.HasPrefix(value, LabelPrefix) {
+			return fmt.Errorf("label %q uses reserved prefix %q and cannot be used", value, LabelPrefix)
 		}
 	}
 	return nil

--- a/defaults.go
+++ b/defaults.go
@@ -40,4 +40,20 @@ const (
 	// workerSwapPollInterval is how often the server-starter status file is
 	// re-read while waiting for the swap.
 	workerSwapPollInterval = 200 * time.Millisecond
+
+	// defaultProxyIdleTimeout is the default idle timeout for TCP proxy
+	// connections. --proxy-idle-timeout overrides it; 0 disables the timeout.
+	defaultProxyIdleTimeout = 5 * time.Minute
+
+	// defaultAdminPort is the port the admin API listens on when --admin-port
+	// is not given. 17539 has no meaning beyond being unlikely to collide.
+	// Both the server (startAdminAPI) and the client ("dewy container list")
+	// side of the API must agree on it.
+	defaultAdminPort = 17539
+
+	// adminPortMaxAttempts is how many consecutive ports are tried from the
+	// configured one. The server increments on bind failure so several dewy
+	// instances can share a host; the client scans the same range to find
+	// them.
+	adminPortMaxAttempts = 10
 )

--- a/dewy.go
+++ b/dewy.go
@@ -38,9 +38,6 @@ const (
 
 	// MaxArtifactSize is the maximum allowed artifact download size (512MB).
 	MaxArtifactSize int64 = 512 * 1024 * 1024
-
-	// defaultProxyIdleTimeout is the default idle timeout for TCP proxy connections.
-	defaultProxyIdleTimeout = 5 * time.Minute
 )
 
 // Dewy struct.


### PR DESCRIPTION
Part 1 of 5 in a stack that removes knowledge duplicated across package boundaries. This one is behavior-preserving.

## Problem

The labels dewy attaches to the containers it deploys were spelled out as string literals in every place that reads or writes them: six sites inside the container package, plus `containerListLabels` in the root package. The root package was therefore coupled to the container package's label scheme by nothing but matching strings, and a typo in any one of them would only surface as containers silently failing to be discovered.

## Change

Export the keys from the container package along with the value `LabelManaged` always takes:

- `LabelPrefix`, `LabelManaged`, `LabelApp`, `LabelVersion`, `LabelReplica`, `LabelDeployedAt`
- `LabelManagedValue`

`reservedLabelPrefix` is folded into `LabelPrefix` so the reserved namespace and the keys built on it are declared together.

## Verification

The label strings themselves are unchanged. The existing tests (`container/runtime_test.go`, `container/docker_test.go`, `admin_api_test.go`) assert the literal values, which is what keeps this refactor honest.

- `go test -race ./...` passes
- `go vet ./...` passes

## Stack

1. **This PR**
2. Collect the duplicated default values in defaults.go
3. Run the deploy hooks through one helper
4. Derive the app name in one place
5. Resolve OCI registry credentials in one place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SB3fn2gWR5KPLVMzf93MGQ