### PR TITLE
Collect the duplicated default values in defaults.go

### DIFF
--- a/admin_api.go
+++ b/admin_api.go
@@ -14,18 +14,16 @@ import (
 
 // startAdminAPI starts the admin API server on TCP localhost.
 func (d *Dewy) startAdminAPI(ctx context.Context) error {
-	// Default admin port is 17539 (DEWY: D=4, E=5, W=23, Y=25 -> 4+5+2+3+2+5=21, but 17539 is more unique)
 	adminPort := d.config.AdminPort
 	if adminPort == 0 {
-		adminPort = 17539
+		adminPort = defaultAdminPort
 	}
 
 	// Try to bind to the port, increment if already in use
 	var listener net.Listener
 	var err error
-	maxAttempts := 10
 
-	for i := range maxAttempts {
+	for i := range adminPortMaxAttempts {
 		currentPort := adminPort + i
 		addr := fmt.Sprintf("localhost:%d", currentPort)
 		listener, err = net.Listen("tcp", addr)
@@ -42,7 +40,7 @@ func (d *Dewy) startAdminAPI(ctx context.Context) error {
 	}
 
 	if listener == nil {
-		return fmt.Errorf("failed to bind admin API after %d attempts: %w", maxAttempts, err)
+		return fmt.Errorf("failed to bind admin API after %d attempts: %w", adminPortMaxAttempts, err)
 	}
 
 	// Create HTTP mux for admin API

--- a/cli.go
+++ b/cli.go
@@ -443,8 +443,8 @@ func (c *cli) configureContainerCommand(conf *Config) error {
 		}
 	}
 
-	// ProxyIdleTimeout: -1 means not specified (use default 5min), 0 means disabled, >0 means custom
-	proxyIdleTimeout := 5 * time.Minute
+	// ProxyIdleTimeout: -1 means not specified (use the default), 0 means disabled, >0 means custom
+	proxyIdleTimeout := defaultProxyIdleTimeout
 	if c.ProxyIdleTimeout == 0 {
 		proxyIdleTimeout = 0 // Explicitly disabled
 	} else if c.ProxyIdleTimeout > 0 {
@@ -702,14 +702,13 @@ https://github.com/linyows/dewy
 
 // runContainerList runs the "dewy container list" command.
 func (c *cli) runContainerList() int {
-	// Default admin port
 	adminPort := c.AdminPort
 	if adminPort == 0 {
-		adminPort = 17539
+		adminPort = defaultAdminPort
 	}
 
-	// Try to connect to admin API, scanning through possible ports
-	maxAttempts := 10
+	// Try to connect to admin API, scanning through the same range of ports
+	// that startAdminAPI increments over.
 	client := &http.Client{
 		Timeout: 2 * time.Second,
 	}
@@ -718,7 +717,7 @@ func (c *cli) runContainerList() int {
 	var err error
 	var successPort int
 
-	for i := range maxAttempts {
+	for i := range adminPortMaxAttempts {
 		currentPort := adminPort + i
 		url := fmt.Sprintf("http://localhost:%d/api/containers", currentPort)
 
@@ -732,7 +731,7 @@ func (c *cli) runContainerList() int {
 
 	if resp == nil {
 		fmt.Fprintf(c.env.Err, "Error: no running dewy instances found (tried ports %d-%d)\n",
-			adminPort, adminPort+maxAttempts-1)
+			adminPort, adminPort+adminPortMaxAttempts-1)
 		return ExitErr
 	}
 	defer resp.Body.Close()

--- a/defaults.go
+++ b/defaults.go
@@ -40,4 +40,20 @@ const (
 	// workerSwapPollInterval is how often the server-starter status file is
 	// re-read while waiting for the swap.
 	workerSwapPollInterval = 200 * time.Millisecond
+
+	// defaultProxyIdleTimeout is the default idle timeout for TCP proxy
+	// connections. --proxy-idle-timeout overrides it; 0 disables the timeout.
+	defaultProxyIdleTimeout = 5 * time.Minute
+
+	// defaultAdminPort is the port the admin API listens on when --admin-port
+	// is not given. 17539 has no meaning beyond being unlikely to collide.
+	// Both the server (startAdminAPI) and the client ("dewy container list")
+	// side of the API must agree on it.
+	defaultAdminPort = 17539
+
+	// adminPortMaxAttempts is how many consecutive ports are tried from the
+	// configured one. The server increments on bind failure so several dewy
+	// instances can share a host; the client scans the same range to find
+	// them.
+	adminPortMaxAttempts = 10
 )

--- a/dewy.go
+++ b/dewy.go
@@ -38,9 +38,6 @@ const (
 
 	// MaxArtifactSize is the maximum allowed artifact download size (512MB).
 	MaxArtifactSize int64 = 512 * 1024 * 1024
-
-	// defaultProxyIdleTimeout is the default idle timeout for TCP proxy connections.
-	defaultProxyIdleTimeout = 5 * time.Minute
 )
 
 // Dewy struct.


### PR DESCRIPTION
Part 2 of 5. Behavior-preserving.

Stacked on #496.

## Problem

The admin API's default port and its bind-retry count were written as literals twice: once in `startAdminAPI`, which increments the port until a bind succeeds, and once in `dewy container list`, which scans the same range looking for a running instance. The two sides have to agree for the CLI to find the server at all, but nothing tied them together.

The proxy idle timeout already had a named constant and `cli.go` still hardcoded the same five minutes next to it.

## Change

- Move `defaultProxyIdleTimeout` to `defaults.go` alongside the other tunables
- Add `defaultAdminPort` and `adminPortMaxAttempts` there
- Point `admin_api.go` and `cli.go` at them

No default changes value.

## Verification

- `go test -race ./...` passes
- `go vet ./...` passes

`admin_api_test.go` exercises the port-increment behavior, so a changed default would be caught there.

## Stack

1. Define the container label keys as package constants (#496)
2. **This PR**
3. Run the deploy hooks through one helper
4. Derive the app name in one place
5. Resolve OCI registry credentials in one place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SB3fn2gWR5KPLVMzf93MGQ