### PR TITLE
Run the deploy hooks through one helper

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -2,6 +2,7 @@ package dewy
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -12,6 +13,42 @@ import (
 	"github.com/cli/safeexec"
 	"github.com/linyows/dewy/notifier"
 )
+
+// deployHook identifies one of the two deploy hooks. The notifier label and
+// the log wording are carried together rather than derived from each other:
+// they differ in capitalization, and both are user-visible.
+type deployHook struct {
+	label  string
+	logMsg string
+}
+
+var (
+	beforeDeployHook = deployHook{label: "Before Deploy", logMsg: "Before deploy hook failure"}
+	afterDeployHook  = deployHook{label: "After Deploy", logMsg: "After deploy hook failure"}
+)
+
+// runDeployHook executes one deploy hook and reports it: the result is sent
+// to the notifier whether or not the hook succeeded, and a failure is logged
+// before the error is returned.
+//
+// Whether a failure aborts the deploy is the caller's decision, not this
+// function's. The before-deploy hook is a gate and its callers return the
+// error; the after-deploy hook runs once the deploy is already final, so its
+// callers discard it (the failure is logged here either way).
+//
+// A blank cmd is a no-op, so callers can pass the configured hook
+// unconditionally.
+func (d *Dewy) runDeployHook(ctx context.Context, h deployHook, cmd string) error {
+	result, err := d.execHook(cmd)
+	if result != nil {
+		d.notifier.SendHookResult(ctx, h.label, result)
+	}
+	if err != nil {
+		d.logger.Error(h.logMsg, slog.String("error", err.Error()))
+		return err
+	}
+	return nil
+}
 
 // execHook runs cmd as a shell command in d.root and returns a HookResult
 // describing the run. A blank cmd is a no-op (returns nil, nil) so callers

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -1,0 +1,100 @@
+package dewy
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/linyows/dewy/logging"
+)
+
+// newHookTestDewy builds the minimum Dewy needed to run a hook: a working
+// directory for the shell command, a notifier to record the result, and a
+// logger writing into buf so the failure wording can be asserted.
+func newHookTestDewy(t *testing.T, buf *bytes.Buffer) (*Dewy, *mockNotify) {
+	t.Helper()
+	n := &mockNotify{}
+	return &Dewy{
+		root:     t.TempDir(),
+		notifier: n,
+		logger:   logging.SetupLogger("ERROR", "text", buf),
+	}, n
+}
+
+// A blank hook command is a no-op: nothing runs, nothing is notified.
+func TestRunDeployHook_Blank(t *testing.T) {
+	var buf bytes.Buffer
+	d, n := newHookTestDewy(t, &buf)
+
+	if err := d.runDeployHook(context.Background(), beforeDeployHook, ""); err != nil {
+		t.Errorf("runDeployHook() with a blank command = %v, want nil", err)
+	}
+	if got := n.GetHookResults(); len(got) != 0 {
+		t.Errorf("hook results = %d, want 0", len(got))
+	}
+}
+
+// A successful hook is notified as successful and returns no error.
+func TestRunDeployHook_Success(t *testing.T) {
+	var buf bytes.Buffer
+	d, n := newHookTestDewy(t, &buf)
+
+	if err := d.runDeployHook(context.Background(), beforeDeployHook, "echo hello"); err != nil {
+		t.Fatalf("runDeployHook() = %v, want nil", err)
+	}
+
+	results := n.GetHookResults()
+	if len(results) != 1 {
+		t.Fatalf("hook results = %d, want 1", len(results))
+	}
+	if !results[0].Success {
+		t.Error("hook result Success = false, want true")
+	}
+	if results[0].Stdout != "hello" {
+		t.Errorf("hook result Stdout = %q, want %q", results[0].Stdout, "hello")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("a successful hook logged at ERROR: %s", buf.String())
+	}
+}
+
+// A failing hook is still notified (so the operator sees the output), is
+// logged with the wording the call sites used before this helper existed, and
+// returns the error for the caller to act on.
+func TestRunDeployHook_Failure(t *testing.T) {
+	tests := []struct {
+		name   string
+		hook   deployHook
+		logMsg string
+	}{
+		{"before", beforeDeployHook, "Before deploy hook failure"},
+		{"after", afterDeployHook, "After deploy hook failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			d, n := newHookTestDewy(t, &buf)
+
+			err := d.runDeployHook(context.Background(), tt.hook, "exit 3")
+			if err == nil {
+				t.Fatal("runDeployHook() = nil, want an error")
+			}
+
+			results := n.GetHookResults()
+			if len(results) != 1 {
+				t.Fatalf("hook results = %d, want 1", len(results))
+			}
+			if results[0].Success {
+				t.Error("hook result Success = true, want false")
+			}
+			if results[0].ExitCode != 3 {
+				t.Errorf("hook result ExitCode = %d, want 3", results[0].ExitCode)
+			}
+			if !strings.Contains(buf.String(), tt.logMsg) {
+				t.Errorf("log = %q, want it to contain %q", buf.String(), tt.logMsg)
+			}
+		})
+	}
+}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -429,17 +429,12 @@ func (d *Dewy) pullContainerImage(ctx context.Context, res *registry.CurrentResp
 // than creating a duplicate. The after-hook runs in promoteContainerAndReport
 // so it only fires once the deploy is considered final.
 func (d *Dewy) applyContainerDeployment(ctx context.Context, res *registry.CurrentResponse, st containerState) (int, error) {
-	beforeResult, beforeErr := d.execHook(d.config.BeforeDeployHook)
-	if beforeResult != nil {
-		d.notifier.SendHookResult(ctx, "Before Deploy", beforeResult)
-	}
-	if beforeErr != nil {
+	if err := d.runDeployHook(ctx, beforeDeployHook, d.config.BeforeDeployHook); err != nil {
 		// Same gate as the server path: a failed before-deploy hook stops the
 		// deploy rather than starting new containers past it. No container has
 		// been touched yet, so the running replicas keep serving and the next
 		// poll retries from the pulled image.
-		d.logger.Error("Before deploy hook failure", slog.String("error", beforeErr.Error()))
-		return 0, fmt.Errorf("before deploy hook failed: %w", beforeErr)
+		return 0, fmt.Errorf("before deploy hook failed: %w", err)
 	}
 
 	deployStart := time.Now()
@@ -463,13 +458,9 @@ func (d *Dewy) promoteContainerAndReport(ctx context.Context, res *registry.Curr
 	d.cVer = res.Tag
 	d.Unlock()
 
-	afterResult, afterErr := d.execHook(d.config.AfterDeployHook)
-	if afterResult != nil {
-		d.notifier.SendHookResult(ctx, "After Deploy", afterResult)
-	}
-	if afterErr != nil {
-		d.logger.Error("After deploy hook failure", slog.String("error", afterErr.Error()))
-	}
+	// The deploy is already final at this point, so a failing after-deploy
+	// hook is logged by runDeployHook and does not fail the run.
+	_ = d.runDeployHook(ctx, afterDeployHook, d.config.AfterDeployHook)
 
 	d.reportDeployment(ctx, res)
 

--- a/release.go
+++ b/release.go
@@ -27,33 +27,23 @@ import (
 func (d *Dewy) deploy(key string) (prevRelease string, err error) {
 	ctx := context.Background()
 
-	beforeResult, beforeErr := d.execHook(d.config.BeforeDeployHook)
-	if beforeResult != nil {
-		d.notifier.SendHookResult(ctx, "Before Deploy", beforeResult)
-	}
-	if beforeErr != nil {
+	if err := d.runDeployHook(ctx, beforeDeployHook, d.config.BeforeDeployHook); err != nil {
 		// The before-deploy hook is a gate: it takes the backup, drains the
 		// load balancer, checks that the preconditions hold. Extracting the
 		// new release past a failed gate is the unsafe direction, so nothing
 		// is touched and the error is returned. The running release stays as
 		// it is, the tick fails, and the next poll retries the hook from the
 		// cached artifact once the cause is gone.
-		d.logger.Error("Before deploy hook failure", slog.String("error", beforeErr.Error()))
-		return "", fmt.Errorf("before deploy hook failed: %w", beforeErr)
+		return "", fmt.Errorf("before deploy hook failed: %w", err)
 	}
 
 	defer func() {
 		if err != nil {
 			return
 		}
-		// When deploy is success, run after deploy hook
-		afterResult, afterErr := d.execHook(d.config.AfterDeployHook)
-		if afterResult != nil {
-			d.notifier.SendHookResult(ctx, "After Deploy", afterResult)
-		}
-		if afterErr != nil {
-			d.logger.Error("After deploy hook failure", slog.String("error", afterErr.Error()))
-		}
+		// When deploy is success, run after deploy hook. Its failure is
+		// logged by runDeployHook and does not undo a live release.
+		_ = d.runDeployHook(ctx, afterDeployHook, d.config.AfterDeployHook)
 	}()
 	// Read the outgoing target before the swap. A missing or non-symlink
 	// path (first deploy, or a directory left by an older dewy) yields an


### PR DESCRIPTION
Part 3 of 5. Behavior-preserving, including the exact log wording.

Stacked on #497.

## Problem

Executing a deploy hook meant repeating the same four steps at three call sites (`release.go` for the server path, and two in `lifecycle.go` for the container path): run it, push the result to the notifier whether or not it passed, log a failure, then decide what the failure means. The three copies had already drifted in shape, and the notifier label and the log wording had to be kept in sync by hand at each one.

## Change

Add `runDeployHook`, which does the reporting and returns the error, leaving the decision to the caller:

- the before-deploy hook is a gate, so its callers abort on the error
- the after-deploy hook runs once the deploy is final, so its callers discard it (the failure is logged either way)

The notifier label and the log wording travel together in a `deployHook` value so they cannot drift.

## Verification

- `go test -race ./...` passes
- `go vet ./...` passes

New `hooks_test.go` covers the blank, success and failure paths, and asserts the failure log keeps the wording the call sites used before (`Before deploy hook failure` / `After deploy hook failure`). The existing hook coverage in `release_test.go` and `lifecycle_test.go` is unchanged.

## Stack

1. Define the container label keys as package constants (#496)
2. Collect the duplicated default values in defaults.go (#497)
3. **This PR**
4. Derive the app name in one place
5. Resolve OCI registry credentials in one place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SB3fn2gWR5KPLVMzf93MGQ